### PR TITLE
Update V2 list memberships to return Membership with embedded User

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   webapp:
     build:
       context: ./webapp
+      args:
+        - GITHUB_PACKAGE_TOKEN=${GITHUB_PACKAGE_TOKEN}
     volumes:
       - ./webapp:/usr/app
     ports:

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -1349,7 +1349,7 @@ const docTemplate = `{
         },
         "/semesters/{semesterId}/memberships": {
             "get": {
-                "description": "Retrieve a list of all Memberships",
+                "description": "Retrieve a list of all Memberships with extended information including email",
                 "consumes": [
                     "application/json"
                 ],
@@ -1367,6 +1367,18 @@ const docTemplate = `{
                         "name": "semesterId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of results to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of results to skip",
+                        "name": "offset",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1375,7 +1387,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/Membership"
+                                "$ref": "#/definitions/MembershipWithAttendance"
                             }
                         }
                     },
@@ -2206,6 +2218,38 @@ const docTemplate = `{
         "Membership": {
             "type": "object",
             "properties": {
+                "discounted": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "paid": {
+                    "type": "boolean"
+                },
+                "ranking": {
+                    "$ref": "#/definitions/Ranking"
+                },
+                "semester": {
+                    "$ref": "#/definitions/Semester"
+                },
+                "semesterId": {
+                    "type": "string"
+                },
+                "user": {
+                    "$ref": "#/definitions/Member"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "MembershipWithAttendance": {
+            "type": "object",
+            "properties": {
+                "attendance": {
+                    "type": "integer"
+                },
                 "discounted": {
                     "type": "boolean"
                 },

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -1341,7 +1341,7 @@
         },
         "/semesters/{semesterId}/memberships": {
             "get": {
-                "description": "Retrieve a list of all Memberships",
+                "description": "Retrieve a list of all Memberships with extended information including email",
                 "consumes": [
                     "application/json"
                 ],
@@ -1359,6 +1359,18 @@
                         "name": "semesterId",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Maximum number of results to return",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of results to skip",
+                        "name": "offset",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1367,7 +1379,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/Membership"
+                                "$ref": "#/definitions/MembershipWithAttendance"
                             }
                         }
                     },
@@ -2198,6 +2210,38 @@
         "Membership": {
             "type": "object",
             "properties": {
+                "discounted": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "paid": {
+                    "type": "boolean"
+                },
+                "ranking": {
+                    "$ref": "#/definitions/Ranking"
+                },
+                "semester": {
+                    "$ref": "#/definitions/Semester"
+                },
+                "semesterId": {
+                    "type": "string"
+                },
+                "user": {
+                    "$ref": "#/definitions/Member"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "MembershipWithAttendance": {
+            "type": "object",
+            "properties": {
+                "attendance": {
+                    "type": "integer"
+                },
                 "discounted": {
                     "type": "boolean"
                 },

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -231,6 +231,27 @@ definitions:
       userId:
         type: integer
     type: object
+  MembershipWithAttendance:
+    properties:
+      attendance:
+        type: integer
+      discounted:
+        type: boolean
+      id:
+        type: string
+      paid:
+        type: boolean
+      ranking:
+        $ref: '#/definitions/Ranking'
+      semester:
+        $ref: '#/definitions/Semester'
+      semesterId:
+        type: string
+      user:
+        $ref: '#/definitions/Member'
+      userId:
+        type: integer
+    type: object
   NewSessionRequest:
     properties:
       password:
@@ -1264,13 +1285,22 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieve a list of all Memberships
+      description: Retrieve a list of all Memberships with extended information including
+        email
       parameters:
       - description: Semester ID
         in: path
         name: semesterId
         required: true
         type: string
+      - description: Maximum number of results to return
+        in: query
+        name: limit
+        type: integer
+      - description: Number of results to skip
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
@@ -1278,7 +1308,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/Membership'
+              $ref: '#/definitions/MembershipWithAttendance'
             type: array
         "400":
           description: Bad Request

--- a/server/internal/controller/memberships.go
+++ b/server/internal/controller/memberships.go
@@ -146,7 +146,7 @@ func (c *membershipsController) parseListMembershipsQueryParams(
 // @Param semesterId path string true "Semester ID"
 // @Param limit query int false "Maximum number of results to return"
 // @Param offset query int false "Number of results to skip"
-// @Success 200 {array} ListMembershipsResponseV2
+// @Success 200 {array} MembershipWithAttendance
 // @Failure 400 {object} ErrorResponse
 // @Failure 401 {object} ErrorResponse
 // @Failure 403 {object} ErrorResponse

--- a/server/internal/models/membership.go
+++ b/server/internal/models/membership.go
@@ -78,15 +78,8 @@ type UpdateMembershipRequestV2 struct {
 	Discounted *bool `json:"discounted" binding:"omitempty"`
 } // @name UpdateMembershipRequest
 
-// ListMembershipsResponseV2 is the response structure for V2 list memberships endpoint
-// with additional fields like email
-type ListMembershipsResponseV2 struct {
-	ID         uuid.UUID `json:"id"`
-	UserID     uint64    `json:"userId"`
-	FirstName  string    `json:"firstName"`
-	LastName   string    `json:"lastName"`
-	Email      string    `json:"email"`
-	Paid       bool      `json:"paid"`
-	Discounted bool      `json:"discounted"`
-	Attendance int       `json:"attendance"`
-} // @name ListMembershipsResponseV2
+// MembershipWithAttendance embeds Membership with computed attendance count
+type MembershipWithAttendance struct {
+	Membership
+	Attendance int `json:"attendance"`
+} // @name MembershipWithAttendance

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -3,8 +3,11 @@ FROM node:24.0.1-alpine
 
 WORKDIR /usr/app
 
-# Copy package.json and package-lock.json files over
-COPY package.json package-lock.json ./
+# Build argument for GitHub Package authentication
+ARG GITHUB_PACKAGE_TOKEN
+
+# Copy package.json, package-lock.json, and .npmrc files over
+COPY package.json package-lock.json .npmrc ./
 
 # Install dependencies
 RUN npm ci

--- a/webapp/src/features/events/components/EventRegister.tsx
+++ b/webapp/src/features/events/components/EventRegister.tsx
@@ -23,7 +23,7 @@ export function EventRegister() {
   }, [eventId]);
 
   const filteredMembers = members.filter((m) =>
-    `${m.firstName} ${m.lastName}`.toLowerCase().includes(query.toLowerCase()),
+    `${m.user.firstName} ${m.user.lastName}`.toLowerCase().includes(query.toLowerCase()),
   );
 
   const handleSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -104,7 +104,7 @@ export function EventRegister() {
 
                     <div className={styles.itemTitle}>
                       <span>
-                        {member.firstName} {member.lastName}
+                        {member.user.firstName} {member.user.lastName}
                       </span>
                     </div>
 

--- a/webapp/src/features/members/components/MembersList.tsx
+++ b/webapp/src/features/members/components/MembersList.tsx
@@ -75,10 +75,10 @@ export function MembersList() {
     const query = debouncedSearchQuery.toLowerCase();
     return members.filter(
       (member) =>
-        member.firstName.toLowerCase().includes(query) ||
-        member.lastName.toLowerCase().includes(query) ||
-        member.email.toLowerCase().includes(query) ||
-        `${member.firstName} ${member.lastName}`.toLowerCase().includes(query),
+        member.user.firstName.toLowerCase().includes(query) ||
+        member.user.lastName.toLowerCase().includes(query) ||
+        member.user.email.toLowerCase().includes(query) ||
+        `${member.user.firstName} ${member.user.lastName}`.toLowerCase().includes(query),
     );
   }, [members, debouncedSearchQuery]);
 
@@ -98,12 +98,12 @@ export function MembersList() {
           bValue = b.userId;
           break;
         case "name":
-          aValue = `${a.firstName} ${a.lastName}`.toLowerCase();
-          bValue = `${b.firstName} ${b.lastName}`.toLowerCase();
+          aValue = `${a.user.firstName} ${a.user.lastName}`.toLowerCase();
+          bValue = `${b.user.firstName} ${b.user.lastName}`.toLowerCase();
           break;
         case "email":
-          aValue = a.email.toLowerCase();
-          bValue = b.email.toLowerCase();
+          aValue = a.user.email.toLowerCase();
+          bValue = b.user.email.toLowerCase();
           break;
         case "status":
           aValue = a.paid ? (a.discounted ? "Discounted" : "Paid") : "Unpaid";
@@ -171,13 +171,13 @@ export function MembersList() {
     {
       key: "name",
       header: "Name",
-      accessor: (row) => `${row.firstName} ${row.lastName}`,
+      accessor: (row) => `${row.user.firstName} ${row.user.lastName}`,
       sortable: true,
     },
     {
       key: "email",
       header: "Email",
-      accessor: "email",
+      accessor: (row) => row.user.email,
       sortable: true,
     },
     {

--- a/webapp/src/features/semesters/components/MembershipsTable.tsx
+++ b/webapp/src/features/semesters/components/MembershipsTable.tsx
@@ -19,7 +19,7 @@ export function MembershipsTable({ semesterId }: MembershipsTableProps) {
   const filteredMemberships = useMemo(() => {
     return (
       memberships?.filter((member) =>
-        `${member.firstName} ${member.lastName}`.toLowerCase().includes(query.toLowerCase()),
+        `${member.user.firstName} ${member.user.lastName}`.toLowerCase().includes(query.toLowerCase()),
       ) || []
     );
   }, [query, memberships]);
@@ -93,9 +93,9 @@ export function MembershipsTable({ semesterId }: MembershipsTableProps) {
               <tr data-qa={`member-${m.id}`} key={m.id}>
                 <td data-qa={`member-userId-${m.userId}`}>{m.userId}</td>
 
-                <td>{m.firstName}</td>
+                <td>{m.user.firstName}</td>
 
-                <td>{m.lastName}</td>
+                <td>{m.user.lastName}</td>
 
                 <td>{m.paid ? "Yes" : "No"}</td>
 

--- a/webapp/src/features/semesters/components/NewMembershipModal.tsx
+++ b/webapp/src/features/semesters/components/NewMembershipModal.tsx
@@ -44,7 +44,7 @@ export function NewMembershipModal({ show, onClose, semesterId }: NewMembershipM
     }
 
     const userIds = users.map((u) => u.id);
-    const memberIds = memberships.map((m) => m.userId);
+    const memberIds = memberships.map((m) => String(m.userId));
 
     const userSet = new Set(userIds);
     const memberSet = new Set(memberIds);

--- a/webapp/src/sdk/memberships/model.ts
+++ b/webapp/src/sdk/memberships/model.ts
@@ -1,8 +1,10 @@
+import type { User } from "../../types/user";
+
 export interface Membership {
   id: string;
   userId: number;
-  firstName: string;
-  lastName: string;
+  user: User;
+  semesterId: string;
   paid: boolean;
   discounted: boolean;
   attendance: number;

--- a/webapp/src/sdk/memberships/responses.ts
+++ b/webapp/src/sdk/memberships/responses.ts
@@ -1,8 +1,10 @@
+import type { User } from "../../types/user";
+
 export type ListMembershipsResponse = {
   id: string;
   userId: number;
-  firstName: string;
-  lastName: string;
+  user: User;
+  semesterId: string;
   paid: boolean;
   discounted: boolean;
   attendance: number;

--- a/webapp/src/types/membership.ts
+++ b/webapp/src/types/membership.ts
@@ -1,9 +1,9 @@
+import type { User } from "./user";
+
 export type Membership = {
   id: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  userId: string;
+  userId: number;
+  user: User;
   semesterId: string;
   paid: boolean;
   discounted: boolean;


### PR DESCRIPTION
## Summary

Updates the V2 list memberships endpoint (`GET /api/v2/semesters/{semesterId}/memberships`) to return a `MembershipWithAttendance` struct with a nested User object instead of the flattened `ListMembershipsResponseV2`.

## Changes

### Backend
- Add `MembershipWithAttendance` struct that embeds `Membership` with computed `Attendance` field
- Rewrite `ListMembershipsV2()` to use GORM `Joins("User")` pattern for eager loading
- Remove deprecated `ListMembershipsResponseV2` struct
- Update Swagger documentation

### Frontend
- Update `Membership` type with nested `user: User` object
- Update SDK types (`model.ts`, `responses.ts`) to match new API response
- Update `MembersList`, `MembershipsTable`, `EventRegister` components for nested user access
- Fix type mismatch in `NewMembershipModal`

### Docker
- Fix webapp build by copying `.npmrc` and passing `GITHUB_PACKAGE_TOKEN` build arg

## API Response Change

**Before:**
```json
{
  "id": "uuid",
  "userId": 12345,
  "firstName": "John",
  "lastName": "Doe",
  "email": "john@example.com",
  "paid": true,
  "discounted": false,
  "attendance": 5
}
```

**After:**
```json
{
  "id": "uuid",
  "userId": 12345,
  "user": {
    "id": 12345,
    "firstName": "John",
    "lastName": "Doe",
    "email": "john@example.com",
    "faculty": "Math",
    "questId": "jdoe"
  },
  "semesterId": "uuid",
  "paid": true,
  "discounted": false,
  "attendance": 5
}
```

## Testing

- Backend service tests: All pass
- Backend controller tests: All pass
- Frontend build: Successful
- Docker build: Successful