### PR TITLE
Implement edit member/membership modal

### DIFF
--- a/webapp/src/features/members/api/memberRegistrationApi.ts
+++ b/webapp/src/features/members/api/memberRegistrationApi.ts
@@ -187,3 +187,91 @@ export async function registerNewMemberWithMembership(
     },
   };
 }
+
+/**
+ * Request type for updating a member
+ */
+export interface UpdateMemberRequest {
+  firstName: string;
+  lastName: string;
+  email: string;
+  faculty: string;
+  questId: string;
+}
+
+/**
+ * Request type for updating a membership
+ */
+export interface UpdateMembershipRequest {
+  paid?: boolean;
+  discounted?: boolean;
+}
+
+/**
+ * Update an existing member's information
+ * @param memberId - The member's ID (student ID)
+ * @param data - Updated member data
+ * @returns Updated member or error
+ */
+export async function updateMember(memberId: string, data: UpdateMemberRequest): Promise<ApiResult<User>> {
+  const { status, data: responseData } = await sendAPIRequest<User | APIErrorResponse>(
+    `v2/members/${memberId}`,
+    "PATCH",
+    data as unknown as Record<string, unknown>,
+  );
+
+  if (status === 200) {
+    return { success: true, data: responseData as User };
+  }
+
+  if (status === 404) {
+    return { success: false, error: "Member not found" };
+  }
+
+  const errorResponse = responseData as APIErrorResponse | undefined;
+  return {
+    success: false,
+    error: errorResponse?.message ?? "Failed to update member",
+  };
+}
+
+/**
+ * Update an existing membership
+ * @param semesterId - The semester ID
+ * @param membershipId - The membership ID
+ * @param data - Updated membership data (paid, discounted)
+ * @returns Updated membership or error
+ */
+export async function updateMembership(
+  semesterId: string,
+  membershipId: string,
+  data: UpdateMembershipRequest,
+): Promise<ApiResult<Membership>> {
+  const { status, data: responseData } = await sendAPIRequest<Membership | APIErrorResponse>(
+    `v2/semesters/${semesterId}/memberships/${membershipId}`,
+    "PATCH",
+    data as unknown as Record<string, unknown>,
+  );
+
+  if (status === 200) {
+    return { success: true, data: responseData as Membership };
+  }
+
+  if (status === 404) {
+    return { success: false, error: "Membership not found" };
+  }
+
+  if (status === 400) {
+    const errorResponse = responseData as APIErrorResponse | undefined;
+    return {
+      success: false,
+      error: errorResponse?.message ?? "Invalid membership data",
+    };
+  }
+
+  const errorResponse = responseData as APIErrorResponse | undefined;
+  return {
+    success: false,
+    error: errorResponse?.message ?? "Failed to update membership",
+  };
+}

--- a/webapp/src/features/members/components/EditMemberModal/EditMemberForm.module.css
+++ b/webapp/src/features/members/components/EditMemberModal/EditMemberForm.module.css
@@ -1,0 +1,12 @@
+.form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+/* Stack fields on mobile */
+@media (max-width: 600px) {
+  .form {
+    grid-template-columns: 1fr;
+  }
+}

--- a/webapp/src/features/members/components/EditMemberModal/EditMemberForm.tsx
+++ b/webapp/src/features/members/components/EditMemberModal/EditMemberForm.tsx
@@ -1,0 +1,95 @@
+import { useFormContext } from "react-hook-form";
+import { FormField, Input, Select } from "@uwpokerclub/components";
+import { FACULTIES } from "../../../../data/constants";
+import type { EditMemberMembershipFormData } from "../../validation/registrationSchema";
+import styles from "./EditMemberForm.module.css";
+
+// Transform FACULTIES array to SelectOption format
+const facultyOptions = FACULTIES.map((faculty) => ({
+  value: faculty,
+  label: faculty,
+}));
+
+interface EditMemberFormProps {
+  studentId: string;
+}
+
+/**
+ * EditMemberForm component - Form fields for editing an existing member
+ *
+ * Student ID is displayed as read-only.
+ * Uses react-hook-form context for form state management.
+ * Must be wrapped in a FormProvider.
+ */
+export function EditMemberForm({ studentId }: EditMemberFormProps) {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<EditMemberMembershipFormData>();
+
+  return (
+    <div className={styles.form}>
+      <FormField label="Student ID" htmlFor="studentId-display">
+        {(props) => <Input {...props} id="studentId-display" type="text" value={studentId} disabled fullWidth />}
+      </FormField>
+
+      <FormField label="Quest ID" htmlFor="member.questId">
+        {(props) => (
+          <Input {...props} {...register("member.questId")} type="text" placeholder="e.g., asmahood" fullWidth />
+        )}
+      </FormField>
+
+      <FormField label="First Name" htmlFor="member.firstName" required error={errors.member?.firstName?.message}>
+        {(props) => (
+          <Input
+            {...props}
+            {...register("member.firstName")}
+            type="text"
+            placeholder="e.g., Adam"
+            error={!!errors.member?.firstName}
+            fullWidth
+          />
+        )}
+      </FormField>
+
+      <FormField label="Last Name" htmlFor="member.lastName" required error={errors.member?.lastName?.message}>
+        {(props) => (
+          <Input
+            {...props}
+            {...register("member.lastName")}
+            type="text"
+            placeholder="e.g., Mahood"
+            error={!!errors.member?.lastName}
+            fullWidth
+          />
+        )}
+      </FormField>
+
+      <FormField label="Email" htmlFor="member.email" required error={errors.member?.email?.message}>
+        {(props) => (
+          <Input
+            {...props}
+            {...register("member.email")}
+            type="email"
+            placeholder="e.g., asmahood@uwaterloo.ca"
+            error={!!errors.member?.email}
+            fullWidth
+          />
+        )}
+      </FormField>
+
+      <FormField label="Faculty" htmlFor="member.faculty" required error={errors.member?.faculty?.message}>
+        {(props) => (
+          <Select
+            {...props}
+            {...register("member.faculty")}
+            options={facultyOptions}
+            placeholder="Select a faculty"
+            error={!!errors.member?.faculty}
+            fullWidth
+          />
+        )}
+      </FormField>
+    </div>
+  );
+}

--- a/webapp/src/features/members/components/EditMemberModal/EditMemberModal.module.css
+++ b/webapp/src/features/members/components/EditMemberModal/EditMemberModal.module.css
@@ -1,0 +1,48 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.content form {
+  width: 100%;
+}
+
+.section {
+  margin-bottom: 1rem;
+  width: 100%;
+}
+
+.sectionTitle {
+  margin: 0 0 1rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-gray-900, #212121);
+}
+
+.errorAlert {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background-color: var(--color-danger-light, #fce8e6);
+  border: 1px solid var(--color-danger, #dc3545);
+  border-radius: 4px;
+  color: var(--color-danger-dark, #a50e0e);
+  font-size: 0.875rem;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .footer {
+    flex-direction: column-reverse;
+  }
+
+  .footer button {
+    width: 100%;
+  }
+}

--- a/webapp/src/features/members/components/EditMemberModal/EditMemberModal.tsx
+++ b/webapp/src/features/members/components/EditMemberModal/EditMemberModal.tsx
@@ -1,0 +1,159 @@
+import { useState, useContext, useCallback, useEffect } from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Modal, Button, useToast } from "@uwpokerclub/components";
+import { SemesterContext } from "../../../../contexts";
+import { EditMemberForm } from "./EditMemberForm";
+import { MembershipConfig } from "../RegisterMemberModal/MembershipConfig";
+import { editMemberMembershipSchema, type EditMemberMembershipFormData } from "../../validation/registrationSchema";
+import { updateMember, updateMembership } from "../../api/memberRegistrationApi";
+import type { Membership } from "../../../../types";
+import styles from "./EditMemberModal.module.css";
+
+export interface EditMemberModalProps {
+  isOpen: boolean;
+  membership: Membership | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * EditMemberModal - Modal for editing existing member and membership details
+ */
+export function EditMemberModal({ isOpen, membership, onClose, onSuccess }: EditMemberModalProps) {
+  const semesterContext = useContext(SemesterContext);
+  const { showToast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const form = useForm<EditMemberMembershipFormData>({
+    resolver: zodResolver(editMemberMembershipSchema),
+    defaultValues: {
+      member: {
+        firstName: "",
+        lastName: "",
+        email: "",
+        faculty: "" as EditMemberMembershipFormData["member"]["faculty"],
+        questId: "",
+      },
+      membership: {
+        paid: false,
+        discounted: false,
+      },
+    },
+  });
+
+  // Reset form with membership data when modal opens or membership changes
+  useEffect(() => {
+    if (isOpen && membership) {
+      form.reset({
+        member: {
+          firstName: membership.user.firstName,
+          lastName: membership.user.lastName,
+          email: membership.user.email,
+          faculty: (membership.user.faculty || "") as EditMemberMembershipFormData["member"]["faculty"],
+          questId: membership.user.questId || "",
+        },
+        membership: {
+          paid: membership.paid,
+          discounted: membership.discounted,
+        },
+      });
+      setSubmitError(null);
+    }
+  }, [isOpen, membership, form]);
+
+  // Handle modal close
+  const handleClose = useCallback(() => {
+    form.reset();
+    setSubmitError(null);
+    onClose();
+  }, [form, onClose]);
+
+  // Handle form submit
+  const handleSubmit = async (data: EditMemberMembershipFormData) => {
+    if (!semesterContext?.currentSemester?.id || !membership) {
+      setSubmitError("No semester or membership selected");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    // Update member data
+    const memberResult = await updateMember(String(membership.userId), {
+      firstName: data.member.firstName,
+      lastName: data.member.lastName,
+      email: data.member.email,
+      faculty: data.member.faculty,
+      questId: data.member.questId || "",
+    });
+
+    if (!memberResult.success) {
+      setIsSubmitting(false);
+      setSubmitError(memberResult.error);
+      showToast({
+        message: memberResult.error,
+        variant: "error",
+        duration: 5000,
+      });
+      return;
+    }
+
+    // Update membership data
+    const membershipResult = await updateMembership(semesterContext.currentSemester.id, membership.id, {
+      paid: data.membership.paid,
+      discounted: data.membership.discounted,
+    });
+
+    setIsSubmitting(false);
+
+    if (membershipResult.success) {
+      showToast({
+        message: `${data.member.firstName} ${data.member.lastName} updated successfully!`,
+        variant: "success",
+        duration: 3000,
+      });
+      onSuccess();
+      handleClose();
+    } else {
+      setSubmitError(membershipResult.error);
+      showToast({
+        message: membershipResult.error,
+        variant: "error",
+        duration: 5000,
+      });
+    }
+  };
+
+  // Footer with actions
+  const footer = (
+    <div className={styles.footer}>
+      <Button variant="tertiary" onClick={handleClose} disabled={isSubmitting}>
+        Cancel
+      </Button>
+      <Button type="submit" form="edit-member-form" disabled={isSubmitting}>
+        {isSubmitting ? "Saving..." : "Save Changes"}
+      </Button>
+    </div>
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="Edit Member" size="lg" footer={footer}>
+      <div className={styles.content}>
+        {/* Error display */}
+        {submitError && <div className={styles.errorAlert}>{submitError}</div>}
+
+        <FormProvider {...form}>
+          <form id="edit-member-form" onSubmit={form.handleSubmit(handleSubmit)} noValidate>
+            <div className={styles.section}>
+              <h3 className={styles.sectionTitle}>Member Details</h3>
+              <EditMemberForm studentId={membership?.userId ? String(membership.userId) : ""} />
+            </div>
+            <MembershipConfig />
+          </form>
+        </FormProvider>
+      </div>
+    </Modal>
+  );
+}

--- a/webapp/src/features/members/components/EditMemberModal/index.ts
+++ b/webapp/src/features/members/components/EditMemberModal/index.ts
@@ -1,0 +1,3 @@
+export { EditMemberModal } from "./EditMemberModal";
+export type { EditMemberModalProps } from "./EditMemberModal";
+export { EditMemberForm } from "./EditMemberForm";

--- a/webapp/src/features/members/components/MembersList.tsx
+++ b/webapp/src/features/members/components/MembersList.tsx
@@ -5,6 +5,7 @@ import { Membership } from "@/types";
 import { useAuth } from "@/hooks";
 import { FaEdit, FaTrash, FaSearch, FaPlus, FaTimes, FaUsers } from "react-icons/fa";
 import { RegisterMemberModal } from "./RegisterMemberModal";
+import { EditMemberModal } from "./EditMemberModal";
 import styles from "./MembersList.module.css";
 
 const ITEMS_PER_PAGE = 25;
@@ -20,6 +21,8 @@ export function MembersList() {
   const [sortKey, setSortKey] = useState<string | undefined>(undefined);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const [isRegisterModalOpen, setIsRegisterModalOpen] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [selectedMembership, setSelectedMembership] = useState<Membership | null>(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
   // Debounce search query
@@ -149,10 +152,21 @@ export function MembersList() {
     setRefreshTrigger((prev) => prev + 1);
   };
 
-  // Handle member actions (placeholders)
-  const handleViewEdit = (memberId: string) => {
-    console.log("View/Edit member:", memberId);
-    alert("View/Edit functionality coming soon!");
+  // Handle edit member
+  const handleViewEdit = (membership: Membership) => {
+    setSelectedMembership(membership);
+    setIsEditModalOpen(true);
+  };
+
+  // Handle edit modal close
+  const handleEditModalClose = () => {
+    setIsEditModalOpen(false);
+    setSelectedMembership(null);
+  };
+
+  // Handle edit success
+  const handleEditSuccess = () => {
+    setRefreshTrigger((prev) => prev + 1);
   };
 
   const handleDelete = (memberId: string) => {
@@ -198,15 +212,16 @@ export function MembersList() {
       sortable: false,
       render: (_value, row) => (
         <div className={styles.actions}>
-          <button
-            className={styles.iconButton}
-            onClick={() => handleViewEdit(row.id)}
-            disabled
-            title="View/Edit member"
-            aria-label="View/Edit member"
-          >
-            <FaEdit />
-          </button>
+          {hasPermission("edit", "membership") && (
+            <button
+              className={styles.iconButton}
+              onClick={() => handleViewEdit(row)}
+              title="Edit member"
+              aria-label="Edit member"
+            >
+              <FaEdit />
+            </button>
+          )}
           <button
             className={`${styles.iconButton} ${styles.danger}`}
             onClick={() => handleDelete(row.id)}
@@ -364,6 +379,14 @@ export function MembersList() {
         isOpen={isRegisterModalOpen}
         onClose={() => setIsRegisterModalOpen(false)}
         onSuccess={handleRegistrationSuccess}
+      />
+
+      {/* Edit Member Modal */}
+      <EditMemberModal
+        isOpen={isEditModalOpen}
+        membership={selectedMembership}
+        onClose={handleEditModalClose}
+        onSuccess={handleEditSuccess}
       />
     </div>
   );

--- a/webapp/src/features/members/validation/registrationSchema.ts
+++ b/webapp/src/features/members/validation/registrationSchema.ts
@@ -59,3 +59,22 @@ export const createModeSchema = z.object({
 });
 
 export type CreateModeFormData = z.infer<typeof createModeSchema>;
+
+// Schema for editing a member (no student ID - it's display only)
+export const editMemberSchema = z.object({
+  questId: z.string().optional(),
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().min(1, "Last name is required"),
+  email: z.string().min(1, "Email is required").email("Invalid email format"),
+  faculty: facultySchema.refine((val) => val !== "", { message: "Faculty is required" }),
+});
+
+export type EditMemberFormData = z.infer<typeof editMemberSchema>;
+
+// Combined schema for edit mode (member details + membership config)
+export const editMemberMembershipSchema = z.object({
+  member: editMemberSchema,
+  membership: membershipSchema,
+});
+
+export type EditMemberMembershipFormData = z.infer<typeof editMemberMembershipSchema>;


### PR DESCRIPTION
## Summary

Adds a modal for editing member details and membership status from the members list page.

## Changes

- Add EditMemberModal and EditMemberForm components
- Add Zod validation schemas for edit mode (editMemberSchema, editMemberMembershipSchema)
- Add updateMember() and updateMembership() API functions
- Integrate modal into MembersList with permission-based visibility
- Edit button only visible to users with edit permission on membership resource
- Form pre-populates with current member data
- Student ID displayed as read-only
- Reuses MembershipConfig component for paid/discounted checkboxes

## Testing

- [x] Build passes
- [x] Lint passes
- [x] Manual testing of edit flow