### PR TITLE
Implement edit event modal

### DIFF
--- a/webapp/src/features/events/components/EditEventModal/EditEventModal.module.css
+++ b/webapp/src/features/events/components/EditEventModal/EditEventModal.module.css
@@ -1,0 +1,48 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.fullWidth {
+  grid-column: 1 / -1;
+}
+
+.loadingState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  gap: 1rem;
+  color: var(--color-gray-600, #757575);
+}
+
+.errorAlert {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background-color: var(--color-danger-light, #fce8e6);
+  border: 1px solid var(--color-danger, #dc3545);
+  border-radius: 4px;
+  color: var(--color-danger-dark, #a50e0e);
+  font-size: 0.875rem;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .form {
+    grid-template-columns: 1fr;
+  }
+}

--- a/webapp/src/features/events/components/EditEventModal/EditEventModal.tsx
+++ b/webapp/src/features/events/components/EditEventModal/EditEventModal.tsx
@@ -1,0 +1,256 @@
+import { useState, useContext, useCallback, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Modal, Button, FormField, Input, Select, Textarea, Spinner, useToast } from "@uwpokerclub/components";
+import { SemesterContext } from "../../../../contexts";
+import { editEventSchema, POKER_FORMATS, type EditEventFormData } from "../../schemas/eventSchema";
+import { fetchEvent, updateEvent } from "../../api/eventApi";
+import styles from "./EditEventModal.module.css";
+
+// Transform POKER_FORMATS to Select options
+const formatOptions = POKER_FORMATS.map((format) => ({
+  value: format,
+  label: format,
+}));
+
+/**
+ * Basic event data from the table row
+ */
+export interface EventData {
+  id: number;
+  name: string;
+  format: string;
+  notes: string;
+  startDate: string;
+  state: number;
+}
+
+export interface EditEventModalProps {
+  isOpen: boolean;
+  event: EventData | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+/**
+ * EditEventModal - Modal for editing existing events
+ *
+ * Fetches full event details on open and pre-populates the form.
+ * Uses SemesterContext for API calls.
+ */
+export function EditEventModal({ isOpen, event, onClose, onSuccess }: EditEventModalProps) {
+  const semesterContext = useContext(SemesterContext);
+  const { showToast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isLoadingEvent, setIsLoadingEvent] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const form = useForm<EditEventFormData>({
+    resolver: zodResolver(editEventSchema),
+    defaultValues: {
+      name: "",
+      startDate: "",
+      format: "" as EditEventFormData["format"],
+      pointsMultiplier: 1,
+      notes: "",
+    },
+  });
+
+  // Fetch full event details and pre-populate form when modal opens
+  useEffect(() => {
+    if (!isOpen || !event || !semesterContext?.currentSemester?.id) {
+      return;
+    }
+
+    let mounted = true;
+
+    const loadEventDetails = async () => {
+      setIsLoadingEvent(true);
+      setSubmitError(null);
+
+      const result = await fetchEvent(semesterContext.currentSemester!.id, event.id);
+
+      if (mounted) {
+        if (result.success) {
+          const eventData = result.data;
+          // Format the date for datetime-local input
+          const startDate = new Date(eventData.startDate);
+          const formattedDate = startDate.toISOString().slice(0, 16);
+
+          form.reset({
+            name: eventData.name,
+            startDate: formattedDate,
+            format: eventData.format as EditEventFormData["format"],
+            pointsMultiplier: eventData.pointsMultiplier,
+            notes: eventData.notes || "",
+          });
+        } else {
+          setSubmitError(`Failed to load event details: ${result.error}`);
+        }
+        setIsLoadingEvent(false);
+      }
+    };
+
+    loadEventDetails();
+
+    return () => {
+      mounted = false;
+    };
+  }, [isOpen, event, semesterContext?.currentSemester, form]);
+
+  // Handle modal close
+  const handleClose = useCallback(() => {
+    form.reset();
+    setSubmitError(null);
+    onClose();
+  }, [form, onClose]);
+
+  // Handle form submit
+  const handleSubmit = async (data: EditEventFormData) => {
+    if (!semesterContext?.currentSemester?.id || !event) {
+      setSubmitError("No semester or event selected");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    const result = await updateEvent(semesterContext.currentSemester.id, event.id, {
+      name: data.name,
+      format: data.format,
+      notes: data.notes || "",
+      startDate: new Date(data.startDate).toISOString(),
+      pointsMultiplier: data.pointsMultiplier,
+    });
+
+    setIsSubmitting(false);
+
+    if (result.success) {
+      showToast({
+        message: `"${data.name}" updated successfully!`,
+        variant: "success",
+        duration: 3000,
+      });
+      onSuccess();
+      handleClose();
+    } else {
+      setSubmitError(result.error);
+      showToast({
+        message: result.error,
+        variant: "error",
+        duration: 5000,
+      });
+    }
+  };
+
+  // Footer with actions
+  const footer = (
+    <div className={styles.footer}>
+      <Button variant="tertiary" onClick={handleClose} disabled={isSubmitting || isLoadingEvent}>
+        Cancel
+      </Button>
+      <Button type="submit" form="edit-event-form" disabled={isSubmitting || isLoadingEvent}>
+        {isSubmitting ? "Saving..." : "Save Changes"}
+      </Button>
+    </div>
+  );
+
+  const {
+    register,
+    formState: { errors },
+  } = form;
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} title="Edit Event" size="lg" footer={footer}>
+      <div className={styles.content}>
+        {/* Error display */}
+        {submitError && <div className={styles.errorAlert}>{submitError}</div>}
+
+        {isLoadingEvent ? (
+          <div className={styles.loadingState}>
+            <Spinner size="lg" />
+            <p>Loading event details...</p>
+          </div>
+        ) : (
+          <form id="edit-event-form" onSubmit={form.handleSubmit(handleSubmit)} noValidate>
+            <div className={styles.form}>
+              <div className={styles.fullWidth}>
+                <FormField label="Event Name" htmlFor="name" required error={errors.name?.message}>
+                  {(props) => (
+                    <Input
+                      {...props}
+                      {...register("name")}
+                      type="text"
+                      placeholder="e.g., Tournament #5"
+                      error={!!errors.name}
+                      fullWidth
+                    />
+                  )}
+                </FormField>
+              </div>
+
+              <FormField label="Start Date" htmlFor="startDate" required error={errors.startDate?.message}>
+                {(props) => (
+                  <Input
+                    {...props}
+                    {...register("startDate")}
+                    type="datetime-local"
+                    error={!!errors.startDate}
+                    fullWidth
+                  />
+                )}
+              </FormField>
+
+              <FormField label="Format" htmlFor="format" required error={errors.format?.message}>
+                {(props) => (
+                  <Select
+                    {...props}
+                    {...register("format")}
+                    options={formatOptions}
+                    placeholder="Select a format"
+                    error={!!errors.format}
+                    fullWidth
+                  />
+                )}
+              </FormField>
+
+              <FormField
+                label="Points Multiplier"
+                htmlFor="pointsMultiplier"
+                required
+                error={errors.pointsMultiplier?.message}
+              >
+                {(props) => (
+                  <Input
+                    {...props}
+                    {...register("pointsMultiplier", { valueAsNumber: true })}
+                    type="number"
+                    min={0}
+                    step={0.5}
+                    placeholder="1"
+                    error={!!errors.pointsMultiplier}
+                    fullWidth
+                  />
+                )}
+              </FormField>
+
+              <div className={styles.fullWidth}>
+                <FormField label="Additional Details" htmlFor="notes">
+                  {(props) => (
+                    <Textarea
+                      {...props}
+                      {...register("notes")}
+                      placeholder="Optional notes about the event..."
+                      rows={3}
+                      fullWidth
+                    />
+                  )}
+                </FormField>
+              </div>
+            </div>
+          </form>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/webapp/src/features/events/components/EditEventModal/index.ts
+++ b/webapp/src/features/events/components/EditEventModal/index.ts
@@ -1,0 +1,2 @@
+export { EditEventModal } from "./EditEventModal";
+export type { EditEventModalProps, EventData } from "./EditEventModal";

--- a/webapp/src/features/events/components/ListEvents.module.css
+++ b/webapp/src/features/events/components/ListEvents.module.css
@@ -281,22 +281,18 @@
     width: 100%;
   }
 
+  /* Prevent text wrapping so table scrolls horizontally */
   .tableWrapper td,
   .tableWrapper th {
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 100px;
   }
 
-  .tableWrapper td:first-child {
-    max-width: 80px;
-  }
-
-  .eventLink {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  /* Larger touch target for mobile */
+  .iconButton {
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
   }
 
   .paginationContainer {

--- a/webapp/src/features/events/components/index.ts
+++ b/webapp/src/features/events/components/index.ts
@@ -3,3 +3,4 @@ export * from "./NewEvent";
 export * from "./EventDetails";
 export * from "./EventRegister";
 export * from "./CreateEventModal";
+export * from "./EditEventModal";

--- a/webapp/src/features/events/schemas/eventSchema.ts
+++ b/webapp/src/features/events/schemas/eventSchema.ts
@@ -53,3 +53,14 @@ export const createEventSchema = z.object({
 });
 
 export type CreateEventFormData = z.infer<typeof createEventSchema>;
+
+// Edit event schema (no structure editing)
+export const editEventSchema = z.object({
+  name: z.string().min(1, "Event name is required"),
+  startDate: z.string().min(1, "Start date is required"),
+  format: formatSchema,
+  pointsMultiplier: z.number().min(0, "Points multiplier must be >= 0"),
+  notes: z.string().optional(),
+});
+
+export type EditEventFormData = z.infer<typeof editEventSchema>;


### PR DESCRIPTION
## Summary

Implements a modal dialog for editing existing events, triggered from the events table dropdown menu.

## Changes

- Add `EditEventModal` component with form pre-population from fetched event data
- Add `editEventSchema` Zod validation schema for edit form
- Add `fetchEvent` and `updateEvent` API functions in eventApi.ts
- Wire up edit modal trigger from events table actions dropdown
- Change edit action from navigation link to modal button
- Fix mobile touch targets (44x44px minimum)
- Fix mobile table scrolling to show full column content

## Technical Details

- Modal fetches full event details on open to ensure current data
- Uses react-hook-form with Zod resolver for validation
- Shares patterns with CreateEventModal and EditMemberModal
- Uses V2 API: `PATCH /api/v2/semesters/{semesterId}/events/{eventId}`

## Testing

- [x] Edit button opens modal from events table
- [x] Form pre-populates with event data
- [x] Validation errors display inline
- [x] Successful edit closes modal and refreshes table
- [x] Mobile touch targets work correctly
- [x] Table scrolls horizontally on mobile