### PR TITLE
Add ComingSoon component and placeholder pages for Inventory, Finances, and Executive

### DIFF
--- a/webapp/src/components/ComingSoon/ComingSoon.module.css
+++ b/webapp/src/components/ComingSoon/ComingSoon.module.css
@@ -1,0 +1,92 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: calc(100vh - 180px);
+  padding: 2rem;
+  background: #f8fafc;
+}
+
+.card {
+  position: relative;
+  width: 100%;
+  max-width: 400px;
+  padding: 2.5rem 2rem 2rem;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  border: 2px solid #e2e8f0;
+}
+
+.badge {
+  position: absolute;
+  top: -12px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.4rem 1rem;
+  background: #f59e0b;
+  color: #1a1f36;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  border-radius: 9999px;
+  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.4);
+}
+
+.iconWrapper {
+  width: 80px;
+  height: 80px;
+  margin: 0 auto 1.5rem;
+  background: linear-gradient(135deg, #1a1f36, #2d3348);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 3px solid #f4b80f;
+}
+
+.icon {
+  font-size: 2rem;
+  color: #f4b80f;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1a1f36;
+  margin: 0 0 0.5rem;
+}
+
+.message {
+  font-size: 0.95rem;
+  color: #64748b;
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 1rem;
+  }
+
+  .card {
+    padding: 2rem 1.5rem 1.5rem;
+  }
+
+  .iconWrapper {
+    width: 64px;
+    height: 64px;
+  }
+
+  .icon {
+    font-size: 1.5rem;
+  }
+
+  .title {
+    font-size: 1.25rem;
+  }
+
+  .message {
+    font-size: 0.875rem;
+  }
+}

--- a/webapp/src/components/ComingSoon/ComingSoon.tsx
+++ b/webapp/src/components/ComingSoon/ComingSoon.tsx
@@ -1,0 +1,19 @@
+import { FaHardHat } from "react-icons/fa";
+import styles from "./ComingSoon.module.css";
+
+export function ComingSoon() {
+  return (
+    <div className={styles.container} role="status" aria-live="polite">
+      <div className={styles.card}>
+        <div className={styles.badge}>NOT READY YET</div>
+
+        <div className={styles.iconWrapper}>
+          <FaHardHat className={styles.icon} />
+        </div>
+
+        <h1 className={styles.title}>Under Construction</h1>
+        <p className={styles.message}>This page is currently being developed.</p>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/components/ComingSoon/index.ts
+++ b/webapp/src/components/ComingSoon/index.ts
@@ -1,0 +1,1 @@
+export { ComingSoon } from "./ComingSoon";

--- a/webapp/src/components/index.ts
+++ b/webapp/src/components/index.ts
@@ -5,6 +5,7 @@ export * from "./AdminNavbar";
 export * from "./Modal";
 export * from "./LoadingScreen";
 export * from "./SelectSearch";
+export * from "./ComingSoon";
 
 import AuthProvider from "./AuthProvider";
 import RequireAuth from "./RequireAuth";

--- a/webapp/src/pages/Admin.tsx
+++ b/webapp/src/pages/Admin.tsx
@@ -5,6 +5,9 @@ import { Semesters } from "./Semesters";
 import { Rankings } from "./Rankings";
 import { Events } from "./Events";
 import { Members } from "./Members";
+import { Inventory } from "./Inventory";
+import { Finances } from "./Finances";
+import { Executive } from "./Executive";
 import AdminLayout from "@/layouts/AdminLayout";
 
 export function Admin() {
@@ -17,6 +20,9 @@ export function Admin() {
         <Route path="/events/*" element={<Events />} />
         <Route path="/semesters/*" element={<Semesters />} />
         <Route path="/rankings/*" element={<Rankings />} />
+        <Route path="/inventory" element={<Inventory />} />
+        <Route path="/finances" element={<Finances />} />
+        <Route path="/executive" element={<Executive />} />
       </Routes>
     </AdminLayout>
   );

--- a/webapp/src/pages/Executive.tsx
+++ b/webapp/src/pages/Executive.tsx
@@ -1,0 +1,5 @@
+import { ComingSoon } from "@/components";
+
+export function Executive() {
+  return <ComingSoon />;
+}

--- a/webapp/src/pages/Finances.tsx
+++ b/webapp/src/pages/Finances.tsx
@@ -1,0 +1,5 @@
+import { ComingSoon } from "@/components";
+
+export function Finances() {
+  return <ComingSoon />;
+}

--- a/webapp/src/pages/Inventory.tsx
+++ b/webapp/src/pages/Inventory.tsx
@@ -1,0 +1,5 @@
+import { ComingSoon } from "@/components";
+
+export function Inventory() {
+  return <ComingSoon />;
+}


### PR DESCRIPTION
## Summary

- Add reusable `ComingSoon` component for pages under development
- Create placeholder pages for Inventory, Finances, and Executive Team
- Add routes for the new pages in Admin.tsx

## Changes

- **ComingSoon component**: Simple centered card with "NOT READY YET" badge, hard hat icon, and descriptive text
- **New pages**: Inventory.tsx, Finances.tsx, Executive.tsx - each renders the ComingSoon component
- **Routing**: Added routes for `/admin/inventory`, `/admin/finances`, `/admin/executive`

## Test Plan

- [x] Build passes
- [x] Lint passes
- [ ] Navigate to each new page and verify the Under Construction message displays correctly