### PR TITLE
Add webmaster login management page

### DIFF
--- a/cypress/e2e/logins-management.cy.ts
+++ b/cypress/e2e/logins-management.cy.ts
@@ -1,0 +1,371 @@
+import { LOGINS } from "../seed";
+
+describe("Logins Management", () => {
+  beforeEach(() => {
+    cy.resetDatabase();
+    cy.login();
+  });
+
+  context("navigation", () => {
+    it("should navigate to logins page from sidenav", () => {
+      cy.visit("/admin");
+      cy.getByData("sidenav").should("exist");
+      cy.getByData("sidenav-webmaster-section").should("exist");
+      cy.getByData("nav-link-manage-logins").click();
+      cy.location("pathname").should("eq", "/admin/logins");
+    });
+
+    it("should display page header", () => {
+      cy.visit("/admin/logins");
+      cy.contains("h1", "Manage Logins").should("be.visible");
+      cy.contains("Create and manage login accounts").should("be.visible");
+    });
+  });
+
+  context("logins table", () => {
+    beforeEach(() => {
+      cy.visit("/admin/logins");
+      cy.getByData("logins-table").should("exist");
+    });
+
+    it("should display all column headers", () => {
+      cy.getByData("sort-username-header").should("be.visible");
+      cy.getByData("sort-role-header").should("be.visible");
+      cy.getByData("sort-linkedMember-header").should("be.visible");
+    });
+
+    it("should display all seeded logins", () => {
+      cy.get("[data-qa^='login-row-']").should("have.length", LOGINS.length);
+    });
+
+    it("should display login with linked member correctly", () => {
+      const loginWithMember = LOGINS.find((l) => l.linkedMember)!;
+
+      cy.getByData(`login-row-${loginWithMember.username}`).within(() => {
+        cy.getByData(`login-username-${loginWithMember.username}`).should(
+          "contain",
+          loginWithMember.username
+        );
+        cy.getByData(`login-role-${loginWithMember.username}`).should("exist");
+        cy.getByData(`login-linkedMember-${loginWithMember.username}`).should(
+          "contain",
+          loginWithMember.linkedMember!.firstName
+        );
+      });
+    });
+
+    it("should display login without linked member correctly", () => {
+      const loginWithoutMember = LOGINS.find((l) => !l.linkedMember)!;
+
+      cy.getByData(`login-linkedMember-${loginWithoutMember.username}`).should(
+        "contain",
+        "No linked member"
+      );
+    });
+
+    it("should display role badges", () => {
+      LOGINS.forEach((login) => {
+        cy.getByData(`login-role-${login.username}`).should("exist");
+      });
+    });
+  });
+
+  context("search functionality", () => {
+    beforeEach(() => {
+      cy.visit("/admin/logins");
+      cy.getByData("logins-table").should("exist");
+    });
+
+    it("should filter by username", () => {
+      cy.getByData("input-logins-search").type("hdrust0");
+
+      cy.getByData("logins-results-info").should("contain", "hdrust0");
+      cy.get("[data-qa^='login-row-']").should("have.length", 1);
+      cy.getByData("login-row-hdrust0").should("exist");
+    });
+
+    it("should filter by role", () => {
+      cy.getByData("input-logins-search").type("executive");
+
+      cy.getByData("logins-results-info").should("contain", "executive");
+      // Should show test_executive and hdrust0 (both executive role)
+      cy.get("[data-qa^='login-row-']").should("have.length", 2);
+    });
+
+    it("should be case-insensitive", () => {
+      cy.getByData("input-logins-search").type("PRESIDENT");
+
+      cy.getByData("logins-results-info").should("contain", "PRESIDENT");
+      cy.get("[data-qa^='login-row-']").should("have.length", 1);
+    });
+
+    it("should show no results state", () => {
+      cy.getByData("input-logins-search").type("nonexistentuser12345");
+
+      cy.getByData("logins-no-results").should("be.visible");
+    });
+
+    it("should clear search and show all logins", () => {
+      // First search to filter
+      cy.getByData("input-logins-search").type("hdrust0");
+      cy.getByData("logins-results-info").should("contain", "hdrust0");
+      cy.get("[data-qa^='login-row-']").should("have.length", 1);
+
+      // Clear search
+      cy.getByData("clear-search-btn").click();
+
+      // Should show all logins again
+      cy.getByData("input-logins-search").should("have.value", "");
+      cy.get("[data-qa^='login-row-']").should("have.length", LOGINS.length);
+    });
+  });
+
+  context("sorting", () => {
+    beforeEach(() => {
+      cy.visit("/admin/logins");
+      cy.getByData("logins-table").should("exist");
+    });
+
+    it("should have clickable sort headers", () => {
+      cy.getByData("sort-username-header").should("exist");
+      cy.getByData("sort-role-header").should("exist");
+      cy.getByData("sort-linkedMember-header").should("exist");
+
+      // Verify clicking headers doesn't cause errors
+      cy.getByData("sort-username-header").click();
+      cy.getByData("sort-role-header").click();
+      cy.getByData("sort-linkedMember-header").click();
+
+      // Table should still be visible
+      cy.getByData("logins-table").should("exist");
+    });
+  });
+
+  context("create login modal", () => {
+    beforeEach(() => {
+      cy.visit("/admin/logins");
+      cy.getByData("logins-table").should("exist");
+    });
+
+    it("should open modal when create button is clicked", () => {
+      cy.getByData("create-login-btn").click();
+      cy.getByData("create-login-modal").should("exist");
+    });
+
+    it("should close modal when cancel is clicked", () => {
+      cy.getByData("create-login-btn").click();
+      cy.getByData("create-login-modal").should("exist");
+
+      cy.getByData("create-login-cancel-btn").click();
+      cy.getByData("create-login-modal").should("not.exist");
+    });
+
+    it("should show validation errors for empty form", () => {
+      cy.getByData("create-login-btn").click();
+      cy.getByData("create-login-modal").should("exist");
+
+      // Try to submit empty form
+      cy.getByData("create-login-submit-btn").click();
+
+      // Should show validation errors (form should still be open)
+      cy.getByData("create-login-modal").should("exist");
+    });
+
+    it("should show validation error for short password", () => {
+      cy.getByData("create-login-btn").click();
+      cy.getByData("create-login-modal").should("exist");
+
+      cy.getByData("input-username").type("newuser");
+      cy.getByData("input-password").type("short");
+      cy.getByData("select-role").select("executive");
+
+      cy.getByData("create-login-submit-btn").click();
+
+      // Should show validation error (modal still open)
+      cy.getByData("create-login-modal").should("exist");
+    });
+
+    it("should create a new login successfully", () => {
+      const newUsername = `testuser_${Date.now()}`;
+
+      cy.getByData("create-login-btn").click();
+      cy.getByData("create-login-modal").should("exist");
+
+      cy.getByData("input-username").type(newUsername);
+      cy.getByData("input-password").type("password123");
+      cy.getByData("select-role").select("executive");
+
+      cy.getByData("create-login-submit-btn").click();
+
+      // Modal should close
+      cy.getByData("create-login-modal").should("not.exist");
+
+      // New login should appear in the table
+      cy.getByData(`login-row-${newUsername}`).should("exist");
+    });
+
+    it("should show error for duplicate username", () => {
+      cy.getByData("create-login-btn").click();
+      cy.getByData("create-login-modal").should("exist");
+
+      // Try to create with existing username
+      cy.getByData("input-username").type("e2e_user");
+      cy.getByData("input-password").type("password123");
+      cy.getByData("select-role").select("executive");
+
+      cy.getByData("create-login-submit-btn").click();
+
+      // Should show error (modal stays open)
+      cy.getByData("create-login-error-alert").should("exist");
+    });
+  });
+
+  context("edit password modal", () => {
+    beforeEach(() => {
+      cy.visit("/admin/logins");
+      cy.getByData("logins-table").should("exist");
+    });
+
+    it("should open modal when edit button is clicked", () => {
+      cy.getByData("edit-password-btn-test_executive").click();
+      cy.getByData("edit-password-modal").should("exist");
+    });
+
+    it("should display username in modal title", () => {
+      cy.getByData("edit-password-btn-test_executive").click();
+      cy.getByData("edit-password-modal").should("contain", "test_executive");
+    });
+
+    it("should close modal when cancel is clicked", () => {
+      cy.getByData("edit-password-btn-test_executive").click();
+      cy.getByData("edit-password-modal").should("exist");
+
+      cy.getByData("edit-password-cancel-btn").click();
+      cy.getByData("edit-password-modal").should("not.exist");
+    });
+
+    it("should show validation error when passwords do not match", () => {
+      cy.getByData("edit-password-btn-test_executive").click();
+      cy.getByData("edit-password-modal").should("exist");
+
+      cy.getByData("input-new-password").type("newpassword123");
+      cy.getByData("input-confirm-password").type("differentpassword");
+
+      cy.getByData("edit-password-submit-btn").click();
+
+      // Should show validation error (modal stays open)
+      cy.getByData("edit-password-modal").should("exist");
+    });
+
+    it("should update password successfully", () => {
+      cy.getByData("edit-password-btn-test_executive").click();
+      cy.getByData("edit-password-modal").should("exist");
+
+      cy.getByData("input-new-password").type("newpassword123");
+      cy.getByData("input-confirm-password").type("newpassword123");
+
+      cy.getByData("edit-password-submit-btn").click();
+
+      // Modal should close
+      cy.getByData("edit-password-modal").should("not.exist");
+    });
+  });
+
+  context("delete login modal", () => {
+    beforeEach(() => {
+      cy.visit("/admin/logins");
+      cy.getByData("logins-table").should("exist");
+    });
+
+    it("should open modal when delete button is clicked", () => {
+      cy.getByData("delete-login-btn-test_executive").click();
+      cy.getByData("delete-login-modal").should("exist");
+    });
+
+    it("should display username in confirmation message", () => {
+      cy.getByData("delete-login-btn-test_executive").click();
+      cy.getByData("delete-login-modal").should("contain", "test_executive");
+    });
+
+    it("should close modal when cancel is clicked", () => {
+      cy.getByData("delete-login-btn-test_executive").click();
+      cy.getByData("delete-login-modal").should("exist");
+
+      cy.getByData("delete-login-cancel-btn").click();
+      cy.getByData("delete-login-modal").should("not.exist");
+    });
+
+    it("should show linked member warning", () => {
+      const loginWithMember = LOGINS.find((l) => l.linkedMember)!;
+
+      cy.getByData(`delete-login-btn-${loginWithMember.username}`).click();
+      cy.getByData("delete-login-modal").should("exist");
+
+      // Should show linked member info
+      cy.getByData("delete-login-modal").should(
+        "contain",
+        loginWithMember.linkedMember!.firstName
+      );
+    });
+
+    it("should delete login successfully", () => {
+      const initialCount = LOGINS.length;
+
+      cy.getByData("delete-login-btn-test_executive").click();
+      cy.getByData("delete-login-modal").should("exist");
+
+      cy.getByData("delete-login-confirm-btn").click();
+
+      // Modal should close
+      cy.getByData("delete-login-modal").should("not.exist");
+
+      // Login should be removed from table
+      cy.getByData("login-row-test_executive").should("not.exist");
+      cy.get("[data-qa^='login-row-']").should("have.length", initialCount - 1);
+    });
+  });
+
+  context("empty state", () => {
+    it("should display empty state when no logins exist", () => {
+      // Mock the API to return empty array
+      cy.intercept("GET", "/api/v2/logins", {
+        statusCode: 200,
+        body: [],
+      }).as("getEmptyLogins");
+
+      cy.visit("/admin/logins");
+      cy.wait("@getEmptyLogins");
+
+      cy.getByData("logins-empty").should("be.visible");
+    });
+  });
+
+  context("loading state", () => {
+    it("should display loading spinner while fetching data", () => {
+      // Delay the API response to see loading state
+      cy.intercept("GET", "/api/v2/logins", {
+        statusCode: 200,
+        body: [],
+        delay: 1000,
+      }).as("getLoginsDelayed");
+
+      cy.visit("/admin/logins");
+      cy.getByData("logins-loading").should("be.visible");
+    });
+  });
+
+  context("error state", () => {
+    it("should display error state on API failure", () => {
+      cy.intercept("GET", "/api/v2/logins", {
+        statusCode: 500,
+        body: { message: "Internal server error" },
+      }).as("getLoginsError");
+
+      cy.visit("/admin/logins");
+      cy.wait("@getLoginsError");
+
+      cy.getByData("logins-error").should("be.visible");
+      cy.getByData("retry-btn").should("exist");
+    });
+  });
+});

--- a/cypress/e2e/sidenav.cy.ts
+++ b/cypress/e2e/sidenav.cy.ts
@@ -240,6 +240,24 @@ describe("SideNav", () => {
       cy.getByData("nav-link-executive-team").should("exist");
     });
 
+    it("should display Webmaster section for webmaster role", () => {
+      // Default e2e_user has WEBMASTER role
+      cy.visit("/admin");
+      cy.getByData("sidenav").should("exist");
+
+      // Webmaster section should be visible
+      cy.getByData("sidenav-webmaster-section").should("exist");
+
+      // Manage Logins link should be visible
+      cy.getByData("nav-link-manage-logins").should("exist");
+    });
+
+    it("should navigate to manage logins when clicked", () => {
+      cy.visit("/admin");
+      cy.getByData("nav-link-manage-logins").click();
+      cy.location("pathname").should("eq", "/admin/logins");
+    });
+
     it("should navigate to inventory when clicked", () => {
       cy.visit("/admin");
       cy.getByData("nav-link-inventory").click();

--- a/cypress/seed.sql
+++ b/cypress/seed.sql
@@ -1,5 +1,12 @@
--- Seed the e2e testing user
+-- Seed the e2e testing user (webmaster)
 INSERT INTO logins (username, password, role) VALUES ('e2e_user', '$2a$10$lzRaELvZxS2JwGsI0jSQueJWvMGfx82iYBuu0nFDCxuwJMabOHoX.', 'webmaster');
+
+-- Seed additional logins for testing logins management
+-- Password for all test logins is 'password123' (bcrypt hash)
+INSERT INTO logins (username, password, role) VALUES
+  ('test_president', '$2a$10$lzRaELvZxS2JwGsI0jSQueJWvMGfx82iYBuu0nFDCxuwJMabOHoX.', 'president'),
+  ('test_executive', '$2a$10$lzRaELvZxS2JwGsI0jSQueJWvMGfx82iYBuu0nFDCxuwJMabOHoX.', 'executive'),
+  ('hdrust0', '$2a$10$lzRaELvZxS2JwGsI0jSQueJWvMGfx82iYBuu0nFDCxuwJMabOHoX.', 'executive');
 
 -- Seed a testing semester
 INSERT INTO semesters 

--- a/cypress/seed.ts
+++ b/cypress/seed.ts
@@ -1,4 +1,4 @@
-import { Event, Membership, Participant, Ranking, User } from "./types";
+import { Event, Login, Membership, Participant, Ranking, User } from "./types";
 
 export const STRUCTURE = {
   id: 1,
@@ -314,5 +314,30 @@ export const RANKINGS: Ranking[] = [
     membershipId: "e5f6a7b8-c9d0-4e1f-2a3b-4c5d6e7f8a9b",
     points: 2,
     attendance: 1,
+  },
+];
+
+// Logins seeded for testing (e2e_user is the main test account)
+export const LOGINS: Login[] = [
+  {
+    username: "e2e_user",
+    role: "webmaster",
+  },
+  {
+    username: "test_president",
+    role: "president",
+  },
+  {
+    username: "test_executive",
+    role: "executive",
+  },
+  {
+    username: "hdrust0",
+    role: "executive",
+    linkedMember: {
+      id: "62958169",
+      firstName: "Heinrik",
+      lastName: "Drust",
+    },
   },
 ];

--- a/cypress/types.ts
+++ b/cypress/types.ts
@@ -68,3 +68,13 @@ export interface Participant {
   placement?: number;
   signedOutAt?: string;
 }
+
+export interface Login {
+  username: string;
+  role: string;
+  linkedMember?: {
+    id: string;
+    firstName: string;
+    lastName: string;
+  };
+}

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -45,6 +45,287 @@ const docTemplate = `{
                 }
             }
         },
+        "/logins": {
+            "get": {
+                "description": "Retrieve a list of all logins with their linked member information",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "List all logins",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LoginWithMember"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new login with the provided credentials",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "Create a new login",
+                "parameters": [
+                    {
+                        "description": "Login details",
+                        "name": "login",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CreateLoginRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/LoginWithMember"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/logins/{username}": {
+            "get": {
+                "description": "Retrieve a login by username with linked member information",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "Get login by username",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Login username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/LoginWithMember"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a login by username",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "Delete login by username",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Login username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/logins/{username}/password": {
+            "patch": {
+                "description": "Change the password for a login",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "Change login password",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Login username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New password",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ChangePasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/members": {
             "get": {
                 "description": "Retrieve a list of Members with optional filters",
@@ -2216,6 +2497,18 @@ const docTemplate = `{
                 }
             }
         },
+        "ChangePasswordRequest": {
+            "type": "object",
+            "required": [
+                "newPassword"
+            ],
+            "properties": {
+                "newPassword": {
+                    "type": "string",
+                    "minLength": 8
+                }
+            }
+        },
         "CreateEntryResult": {
             "type": "object",
             "properties": {
@@ -2265,6 +2558,36 @@ const docTemplate = `{
                 },
                 "structureId": {
                     "type": "integer"
+                }
+            }
+        },
+        "CreateLoginRequest": {
+            "type": "object",
+            "required": [
+                "password",
+                "role",
+                "username"
+            ],
+            "properties": {
+                "password": {
+                    "type": "string",
+                    "minLength": 8
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "bot",
+                        "executive",
+                        "tournament_director",
+                        "secretary",
+                        "treasurer",
+                        "vice_president",
+                        "president",
+                        "webmaster"
+                    ]
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },
@@ -2454,6 +2777,34 @@ const docTemplate = `{
                         "type": "object",
                         "additionalProperties": {}
                     }
+                },
+                "role": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "LinkedMemberInfo": {
+            "type": "object",
+            "properties": {
+                "firstName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "lastName": {
+                    "type": "string"
+                }
+            }
+        },
+        "LoginWithMember": {
+            "type": "object",
+            "properties": {
+                "linkedMember": {
+                    "$ref": "#/definitions/LinkedMemberInfo"
                 },
                 "role": {
                     "type": "string"

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -37,6 +37,287 @@
                 }
             }
         },
+        "/logins": {
+            "get": {
+                "description": "Retrieve a list of all logins with their linked member information",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "List all logins",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LoginWithMember"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Create a new login with the provided credentials",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "Create a new login",
+                "parameters": [
+                    {
+                        "description": "Login details",
+                        "name": "login",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CreateLoginRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/LoginWithMember"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/logins/{username}": {
+            "get": {
+                "description": "Retrieve a login by username with linked member information",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "Get login by username",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Login username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/LoginWithMember"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete a login by username",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "Delete login by username",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Login username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/logins/{username}/password": {
+            "patch": {
+                "description": "Change the password for a login",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logins"
+                ],
+                "summary": "Change login password",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Login username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New password",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ChangePasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/members": {
             "get": {
                 "description": "Retrieve a list of Members with optional filters",
@@ -2208,6 +2489,18 @@
                 }
             }
         },
+        "ChangePasswordRequest": {
+            "type": "object",
+            "required": [
+                "newPassword"
+            ],
+            "properties": {
+                "newPassword": {
+                    "type": "string",
+                    "minLength": 8
+                }
+            }
+        },
         "CreateEntryResult": {
             "type": "object",
             "properties": {
@@ -2257,6 +2550,36 @@
                 },
                 "structureId": {
                     "type": "integer"
+                }
+            }
+        },
+        "CreateLoginRequest": {
+            "type": "object",
+            "required": [
+                "password",
+                "role",
+                "username"
+            ],
+            "properties": {
+                "password": {
+                    "type": "string",
+                    "minLength": 8
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "bot",
+                        "executive",
+                        "tournament_director",
+                        "secretary",
+                        "treasurer",
+                        "vice_president",
+                        "president",
+                        "webmaster"
+                    ]
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },
@@ -2446,6 +2769,34 @@
                         "type": "object",
                         "additionalProperties": {}
                     }
+                },
+                "role": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "LinkedMemberInfo": {
+            "type": "object",
+            "properties": {
+                "firstName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "lastName": {
+                    "type": "string"
+                }
+            }
+        },
+        "LoginWithMember": {
+            "type": "object",
+            "properties": {
+                "linkedMember": {
+                    "$ref": "#/definitions/LinkedMemberInfo"
                 },
                 "role": {
                     "type": "string"

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -10,6 +10,14 @@ definitions:
       time:
         type: integer
     type: object
+  ChangePasswordRequest:
+    properties:
+      newPassword:
+        minLength: 8
+        type: string
+    required:
+    - newPassword
+    type: object
   CreateEntryResult:
     properties:
       error:
@@ -45,6 +53,29 @@ definitions:
     - semesterId
     - startDate
     - structureId
+    type: object
+  CreateLoginRequest:
+    properties:
+      password:
+        minLength: 8
+        type: string
+      role:
+        enum:
+        - bot
+        - executive
+        - tournament_director
+        - secretary
+        - treasurer
+        - vice_president
+        - president
+        - webmaster
+        type: string
+      username:
+        type: string
+    required:
+    - password
+    - role
+    - username
     type: object
   CreateMemberRequest:
     properties:
@@ -178,6 +209,24 @@ definitions:
           additionalProperties: {}
           type: object
         type: object
+      role:
+        type: string
+      username:
+        type: string
+    type: object
+  LinkedMemberInfo:
+    properties:
+      firstName:
+        type: string
+      id:
+        type: integer
+      lastName:
+        type: string
+    type: object
+  LoginWithMember:
+    properties:
+      linkedMember:
+        $ref: '#/definitions/LinkedMemberInfo'
       role:
         type: string
       username:
@@ -446,6 +495,192 @@ paths:
       summary: Health Check
       tags:
       - Health
+  /logins:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve a list of all logins with their linked member information
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/LoginWithMember'
+            type: array
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: List all logins
+      tags:
+      - Logins
+    post:
+      consumes:
+      - application/json
+      description: Create a new login with the provided credentials
+      parameters:
+      - description: Login details
+        in: body
+        name: login
+        required: true
+        schema:
+          $ref: '#/definitions/CreateLoginRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/LoginWithMember'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Create a new login
+      tags:
+      - Logins
+  /logins/{username}:
+    delete:
+      consumes:
+      - application/json
+      description: Delete a login by username
+      parameters:
+      - description: Login username
+        in: path
+        name: username
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Delete login by username
+      tags:
+      - Logins
+    get:
+      consumes:
+      - application/json
+      description: Retrieve a login by username with linked member information
+      parameters:
+      - description: Login username
+        in: path
+        name: username
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/LoginWithMember'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Get login by username
+      tags:
+      - Logins
+  /logins/{username}/password:
+    patch:
+      consumes:
+      - application/json
+      description: Change the password for a login
+      parameters:
+      - description: Login username
+        in: path
+        name: username
+        required: true
+        type: string
+      - description: New password
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/ChangePasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: Change login password
+      tags:
+      - Logins
   /members:
     get:
       consumes:

--- a/server/internal/authorization/login_authorizer.go
+++ b/server/internal/authorization/login_authorizer.go
@@ -8,14 +8,14 @@ type loginAuthorizer struct {
 // NewLoginAuthorizer creates a new login authorizer.
 func NewLoginAuthorizer() ResourceAuthorizer {
 	return &loginAuthorizer{
-		actions: []string{"create"},
+		actions: []string{"create", "list", "get", "delete", "edit"},
 	}
 }
 
 // IsAuthorized checks if the user is authorized to perform the action.
 func (svc *loginAuthorizer) IsAuthorized(role string, action string) bool {
 	switch action {
-	case "create":
+	case "create", "list", "get", "delete", "edit":
 		return HasRole(ROLE_WEBMASTER, role)
 	}
 

--- a/server/internal/authorization/login_authorizer_test.go
+++ b/server/internal/authorization/login_authorizer_test.go
@@ -52,6 +52,54 @@ func TestLoginAuthorizer(t *testing.T) {
 			},
 			action: "create",
 		},
+		{
+			name: "List Authorized",
+			roles: []struct {
+				role     string
+				expected bool
+			}{
+				{role: ROLE_BOT.ToString(), expected: false},
+				{role: ROLE_EXECUTIVE.ToString(), expected: false},
+				{role: ROLE_WEBMASTER.ToString(), expected: true},
+			},
+			action: "list",
+		},
+		{
+			name: "Get Authorized",
+			roles: []struct {
+				role     string
+				expected bool
+			}{
+				{role: ROLE_BOT.ToString(), expected: false},
+				{role: ROLE_EXECUTIVE.ToString(), expected: false},
+				{role: ROLE_WEBMASTER.ToString(), expected: true},
+			},
+			action: "get",
+		},
+		{
+			name: "Delete Authorized",
+			roles: []struct {
+				role     string
+				expected bool
+			}{
+				{role: ROLE_BOT.ToString(), expected: false},
+				{role: ROLE_EXECUTIVE.ToString(), expected: false},
+				{role: ROLE_WEBMASTER.ToString(), expected: true},
+			},
+			action: "delete",
+		},
+		{
+			name: "Edit Authorized",
+			roles: []struct {
+				role     string
+				expected bool
+			}{
+				{role: ROLE_BOT.ToString(), expected: false},
+				{role: ROLE_EXECUTIVE.ToString(), expected: false},
+				{role: ROLE_WEBMASTER.ToString(), expected: true},
+			},
+			action: "edit",
+		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.name, func(t *testing.T) {
@@ -75,6 +123,10 @@ func TestLoginAuthorizer_GetPermissions(t *testing.T) {
 			role: "tournament_director",
 			expected: map[string]any{
 				"create": false,
+				"list":   false,
+				"get":    false,
+				"delete": false,
+				"edit":   false,
 			},
 		},
 	}

--- a/server/internal/controller/logins.go
+++ b/server/internal/controller/logins.go
@@ -1,0 +1,250 @@
+package controller
+
+import (
+	apierrors "api/internal/errors"
+	"api/internal/middleware"
+	"api/internal/models"
+	"api/internal/services"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type loginsController struct {
+	db *gorm.DB
+}
+
+// NewLoginsController creates a new instance of loginsController
+func NewLoginsController(db *gorm.DB) Controller {
+	return &loginsController{db: db}
+}
+
+func (c *loginsController) LoadRoutes(router *gin.RouterGroup) {
+	logins := router.Group("logins", middleware.UseAuthentication(c.db))
+	logins.GET("", middleware.UseAuthorization(c.db, "login.list"), c.listLogins)
+	logins.GET("/:username", middleware.UseAuthorization(c.db, "login.get"), c.getLogin)
+	logins.POST("", middleware.UseAuthorization(c.db, "login.create"), c.createLogin)
+	logins.DELETE("/:username", middleware.UseAuthorization(c.db, "login.delete"), c.deleteLogin)
+	logins.PATCH("/:username/password", middleware.UseAuthorization(c.db, "login.edit"), c.changePassword)
+}
+
+// listLogins handles listing all logins with linked member information
+//
+// @Summary List all logins
+// @Description Retrieve a list of all logins with their linked member information
+// @Tags Logins
+// @Accept json
+// @Produce json
+// @Success 200 {array} LoginWithMember
+// @Failure 401 {object} ErrorResponse
+// @Failure 403 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /logins [get]
+func (c *loginsController) listLogins(ctx *gin.Context) {
+	svc := services.NewLoginService(c.db)
+	logins, err := svc.ListLogins()
+	if err != nil {
+		if apiErr, ok := err.(apierrors.APIErrorResponse); ok {
+			ctx.AbortWithStatusJSON(apiErr.Code, apiErr)
+			return
+		}
+
+		ctx.AbortWithStatusJSON(
+			http.StatusInternalServerError,
+			apierrors.InternalServerError(err.Error()),
+		)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, logins)
+}
+
+// getLogin handles retrieving a single login by username
+//
+// @Summary Get login by username
+// @Description Retrieve a login by username with linked member information
+// @Tags Logins
+// @Accept json
+// @Produce json
+// @Param username path string true "Login username"
+// @Success 200 {object} LoginWithMember
+// @Failure 401 {object} ErrorResponse
+// @Failure 403 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /logins/{username} [get]
+func (c *loginsController) getLogin(ctx *gin.Context) {
+	username := ctx.Param("username")
+	if username == "" {
+		ctx.AbortWithStatusJSON(
+			http.StatusBadRequest,
+			apierrors.InvalidRequest("username parameter is required"),
+		)
+		return
+	}
+
+	svc := services.NewLoginService(c.db)
+	login, err := svc.GetLogin(username)
+	if err != nil {
+		if apiErr, ok := err.(apierrors.APIErrorResponse); ok {
+			ctx.AbortWithStatusJSON(apiErr.Code, apiErr)
+			return
+		}
+
+		ctx.AbortWithStatusJSON(
+			http.StatusInternalServerError,
+			apierrors.InternalServerError(err.Error()),
+		)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, login)
+}
+
+// createLogin handles the creation of a new login
+//
+// @Summary Create a new login
+// @Description Create a new login with the provided credentials
+// @Tags Logins
+// @Accept json
+// @Produce json
+// @Param login body CreateLoginRequest true "Login details"
+// @Success 201 {object} LoginWithMember
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 403 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /logins [post]
+func (c *loginsController) createLogin(ctx *gin.Context) {
+	var req models.CreateLoginRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, apierrors.InvalidRequest(err.Error()))
+		return
+	}
+
+	svc := services.NewLoginService(c.db)
+	err := svc.CreateLoginFromRequest(&req)
+	if err != nil {
+		if apiErr, ok := err.(apierrors.APIErrorResponse); ok {
+			ctx.AbortWithStatusJSON(apiErr.Code, apiErr)
+			return
+		}
+
+		ctx.AbortWithStatusJSON(
+			http.StatusInternalServerError,
+			apierrors.InternalServerError(err.Error()),
+		)
+		return
+	}
+
+	// Return the created login (without password)
+	login, err := svc.GetLogin(req.Username)
+	if err != nil {
+		if apiErr, ok := err.(apierrors.APIErrorResponse); ok {
+			ctx.AbortWithStatusJSON(apiErr.Code, apiErr)
+			return
+		}
+
+		ctx.AbortWithStatusJSON(
+			http.StatusInternalServerError,
+			apierrors.InternalServerError(err.Error()),
+		)
+		return
+	}
+
+	ctx.JSON(http.StatusCreated, login)
+}
+
+// deleteLogin handles deleting a login by username
+//
+// @Summary Delete login by username
+// @Description Delete a login by username
+// @Tags Logins
+// @Accept json
+// @Produce json
+// @Param username path string true "Login username"
+// @Success 204 "No Content"
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 403 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /logins/{username} [delete]
+func (c *loginsController) deleteLogin(ctx *gin.Context) {
+	username := ctx.Param("username")
+	if username == "" {
+		ctx.AbortWithStatusJSON(
+			http.StatusBadRequest,
+			apierrors.InvalidRequest("username parameter is required"),
+		)
+		return
+	}
+
+	svc := services.NewLoginService(c.db)
+	err := svc.DeleteLogin(username)
+	if err != nil {
+		if apiErr, ok := err.(apierrors.APIErrorResponse); ok {
+			ctx.AbortWithStatusJSON(apiErr.Code, apiErr)
+			return
+		}
+
+		ctx.AbortWithStatusJSON(
+			http.StatusInternalServerError,
+			apierrors.InternalServerError(err.Error()),
+		)
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+// changePassword handles changing a login's password
+//
+// @Summary Change login password
+// @Description Change the password for a login
+// @Tags Logins
+// @Accept json
+// @Produce json
+// @Param username path string true "Login username"
+// @Param request body ChangePasswordRequest true "New password"
+// @Success 204 "No Content"
+// @Failure 400 {object} ErrorResponse
+// @Failure 401 {object} ErrorResponse
+// @Failure 403 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /logins/{username}/password [patch]
+func (c *loginsController) changePassword(ctx *gin.Context) {
+	username := ctx.Param("username")
+	if username == "" {
+		ctx.AbortWithStatusJSON(
+			http.StatusBadRequest,
+			apierrors.InvalidRequest("username parameter is required"),
+		)
+		return
+	}
+
+	var req models.ChangePasswordRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, apierrors.InvalidRequest(err.Error()))
+		return
+	}
+
+	svc := services.NewLoginService(c.db)
+	err := svc.ChangePassword(username, req.NewPassword)
+	if err != nil {
+		if apiErr, ok := err.(apierrors.APIErrorResponse); ok {
+			ctx.AbortWithStatusJSON(apiErr.Code, apiErr)
+			return
+		}
+
+		ctx.AbortWithStatusJSON(
+			http.StatusInternalServerError,
+			apierrors.InternalServerError(err.Error()),
+		)
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}

--- a/server/internal/controller/logins_test.go
+++ b/server/internal/controller/logins_test.go
@@ -1,0 +1,513 @@
+package controller_test
+
+import (
+	"api/internal/authorization"
+	"api/internal/models"
+	"api/internal/testutils"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// All non-webmaster roles - logins endpoints are webmaster-only
+var loginsUnauthorizedRoles = []string{
+	authorization.ROLE_BOT.ToString(),
+	authorization.ROLE_EXECUTIVE.ToString(),
+	authorization.ROLE_TOURNAMENT_DIRECTOR.ToString(),
+	authorization.ROLE_SECRETARY.ToString(),
+	authorization.ROLE_TREASURER.ToString(),
+	authorization.ROLE_VICE_PRESIDENT.ToString(),
+	authorization.ROLE_PRESIDENT.ToString(),
+}
+
+func TestListLogins(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	apiServer := testutils.NewTestAPIServer(db)
+
+	// Test unauthorized/forbidden access
+	testutils.TestInvalidAuthForEndpoint(t, container, apiServer, "GET", "/api/v2/logins", loginsUnauthorizedRoles)
+
+	testCases := []struct {
+		name           string
+		setupLogins    func()
+		expectedStatus int
+		expectedCount  int
+	}{
+		{
+			name:           "empty list",
+			setupLogins:    func() {},
+			expectedStatus: http.StatusOK,
+			expectedCount:  0,
+		},
+		{
+			name: "list multiple logins",
+			setupLogins: func() {
+				db.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"})
+				db.Create(&models.Login{Username: "bob", Password: "hash2", Role: "president"})
+			},
+			expectedStatus: http.StatusOK,
+			expectedCount:  2,
+		},
+		{
+			name: "list logins with linked member",
+			setupLogins: func() {
+				// Create user with QuestID matching login username
+				db.Create(&models.User{
+					ID:        12345678,
+					FirstName: "John",
+					LastName:  "Doe",
+					Email:     "john@example.com",
+					Faculty:   "Math",
+					QuestID:   "jdoe",
+				})
+				db.Create(&models.Login{Username: "jdoe", Password: "hash1", Role: "executive"})
+				db.Create(&models.Login{Username: "webmaster", Password: "hash2", Role: "webmaster"})
+			},
+			expectedStatus: http.StatusOK,
+			expectedCount:  2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset database for clean state
+			require.NoError(t, container.ResetDatabase(ctx))
+
+			// Setup test data
+			tc.setupLogins()
+
+			// Setup authentication as webmaster
+			sessionID, err := testutils.CreateTestSession(db, "testwebmaster", authorization.ROLE_WEBMASTER.ToString())
+			require.NoError(t, err)
+
+			// Create request
+			req, err := testutils.MakeJSONRequest("GET", "/api/v2/logins", nil)
+			require.NoError(t, err)
+			testutils.SetAuthCookie(req, sessionID)
+
+			// Execute request
+			w := httptest.NewRecorder()
+			apiServer.ServeHTTP(w, req)
+
+			require.Equal(t, tc.expectedStatus, w.Code, "Response: %s", w.Body.String())
+
+			var logins []models.LoginWithMember
+			err = json.Unmarshal(w.Body.Bytes(), &logins)
+			require.NoError(t, err)
+
+			// Account for the webmaster session login created for auth (+1 if expectedCount > 0 for setup logins)
+			// Actually the session creates its own login, so we need to account for that
+			// The test webmaster login is separate, so expected count should be setup count + 1 (webmaster session)
+			require.Len(t, logins, tc.expectedCount+1) // +1 for testwebmaster session login
+		})
+	}
+}
+
+func TestGetLogin(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	apiServer := testutils.NewTestAPIServer(db)
+
+	// Test unauthorized/forbidden access
+	testutils.TestInvalidAuthForEndpoint(t, container, apiServer, "GET", "/api/v2/logins/testuser", loginsUnauthorizedRoles)
+
+	testCases := []struct {
+		name           string
+		username       string
+		setupLogin     func()
+		expectedStatus int
+		expectError    bool
+	}{
+		{
+			name:     "successful retrieval",
+			username: "alice",
+			setupLogin: func() {
+				db.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"})
+			},
+			expectedStatus: http.StatusOK,
+			expectError:    false,
+		},
+		{
+			name:     "with linked member",
+			username: "jdoe",
+			setupLogin: func() {
+				db.Create(&models.User{
+					ID:        12345678,
+					FirstName: "John",
+					LastName:  "Doe",
+					Email:     "john@example.com",
+					Faculty:   "Math",
+					QuestID:   "jdoe",
+				})
+				db.Create(&models.Login{Username: "jdoe", Password: "hash1", Role: "executive"})
+			},
+			expectedStatus: http.StatusOK,
+			expectError:    false,
+		},
+		{
+			name:           "not found",
+			username:       "nonexistent",
+			setupLogin:     func() {},
+			expectedStatus: http.StatusNotFound,
+			expectError:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset database for clean state
+			require.NoError(t, container.ResetDatabase(ctx))
+
+			// Setup test data
+			tc.setupLogin()
+
+			// Setup authentication as webmaster
+			sessionID, err := testutils.CreateTestSession(db, "testwebmaster", authorization.ROLE_WEBMASTER.ToString())
+			require.NoError(t, err)
+
+			// Create request
+			req, err := testutils.MakeJSONRequest("GET", "/api/v2/logins/"+tc.username, nil)
+			require.NoError(t, err)
+			testutils.SetAuthCookie(req, sessionID)
+
+			// Execute request
+			w := httptest.NewRecorder()
+			apiServer.ServeHTTP(w, req)
+
+			require.Equal(t, tc.expectedStatus, w.Code, "Response: %s", w.Body.String())
+
+			if !tc.expectError {
+				var login models.LoginWithMember
+				err := json.Unmarshal(w.Body.Bytes(), &login)
+				require.NoError(t, err)
+				require.Equal(t, tc.username, login.Username)
+			}
+		})
+	}
+}
+
+func TestCreateLogin(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	apiServer := testutils.NewTestAPIServer(db)
+
+	// Test unauthorized/forbidden access
+	testutils.TestInvalidAuthForEndpoint(t, container, apiServer, "POST", "/api/v2/logins", loginsUnauthorizedRoles, map[string]any{
+		"username": "newuser",
+		"password": "password123",
+		"role":     "executive",
+	})
+
+	testCases := []struct {
+		name                 string
+		requestBody          map[string]any
+		expectedStatus       int
+		expectError          bool
+		expectedErrorMessage string
+	}{
+		{
+			name: "successful creation",
+			requestBody: map[string]any{
+				"username": "newuser",
+				"password": "password123",
+				"role":     "executive",
+			},
+			expectedStatus: http.StatusCreated,
+			expectError:    false,
+		},
+		{
+			name: "missing username",
+			requestBody: map[string]any{
+				"password": "password123",
+				"role":     "executive",
+			},
+			expectedStatus:       http.StatusBadRequest,
+			expectError:          true,
+			expectedErrorMessage: "Key: 'CreateLoginRequest.Username' Error:Field validation for 'Username' failed on the 'required' tag",
+		},
+		{
+			name: "missing password",
+			requestBody: map[string]any{
+				"username": "newuser",
+				"role":     "executive",
+			},
+			expectedStatus:       http.StatusBadRequest,
+			expectError:          true,
+			expectedErrorMessage: "Key: 'CreateLoginRequest.Password' Error:Field validation for 'Password' failed on the 'required' tag",
+		},
+		{
+			name: "password too short",
+			requestBody: map[string]any{
+				"username": "newuser",
+				"password": "short",
+				"role":     "executive",
+			},
+			expectedStatus:       http.StatusBadRequest,
+			expectError:          true,
+			expectedErrorMessage: "Key: 'CreateLoginRequest.Password' Error:Field validation for 'Password' failed on the 'min' tag",
+		},
+		{
+			name: "missing role",
+			requestBody: map[string]any{
+				"username": "newuser",
+				"password": "password123",
+			},
+			expectedStatus:       http.StatusBadRequest,
+			expectError:          true,
+			expectedErrorMessage: "Key: 'CreateLoginRequest.Role' Error:Field validation for 'Role' failed on the 'required' tag",
+		},
+		{
+			name: "invalid role",
+			requestBody: map[string]any{
+				"username": "newuser",
+				"password": "password123",
+				"role":     "invalid_role",
+			},
+			expectedStatus:       http.StatusBadRequest,
+			expectError:          true,
+			expectedErrorMessage: "Key: 'CreateLoginRequest.Role' Error:Field validation for 'Role' failed on the 'oneof' tag",
+		},
+		{
+			name: "create webmaster role",
+			requestBody: map[string]any{
+				"username": "newwebmaster",
+				"password": "password123",
+				"role":     "webmaster",
+			},
+			expectedStatus: http.StatusCreated,
+			expectError:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset database for clean state
+			require.NoError(t, container.ResetDatabase(ctx))
+
+			// Setup authentication as webmaster
+			sessionID, err := testutils.CreateTestSession(db, "testwebmaster", authorization.ROLE_WEBMASTER.ToString())
+			require.NoError(t, err)
+
+			// Create request
+			req, err := testutils.MakeJSONRequest("POST", "/api/v2/logins", tc.requestBody)
+			require.NoError(t, err)
+			testutils.SetAuthCookie(req, sessionID)
+
+			// Execute request
+			w := httptest.NewRecorder()
+			apiServer.ServeHTTP(w, req)
+
+			require.Equal(t, tc.expectedStatus, w.Code, "Response: %s", w.Body.String())
+
+			if tc.expectError {
+				testutils.AssertErrorResponse(t, w, tc.expectedStatus, tc.expectedErrorMessage)
+			} else {
+				var login models.LoginWithMember
+				err := json.Unmarshal(w.Body.Bytes(), &login)
+				require.NoError(t, err)
+				require.Equal(t, tc.requestBody["username"], login.Username)
+				require.Equal(t, tc.requestBody["role"], login.Role)
+			}
+		})
+	}
+}
+
+func TestDeleteLogin(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	apiServer := testutils.NewTestAPIServer(db)
+
+	// Test unauthorized/forbidden access
+	testutils.TestInvalidAuthForEndpoint(t, container, apiServer, "DELETE", "/api/v2/logins/testuser", loginsUnauthorizedRoles)
+
+	testCases := []struct {
+		name           string
+		username       string
+		setupLogin     func()
+		expectedStatus int
+	}{
+		{
+			name:     "successful deletion",
+			username: "alice",
+			setupLogin: func() {
+				db.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"})
+			},
+			expectedStatus: http.StatusNoContent,
+		},
+		{
+			name:           "not found",
+			username:       "nonexistent",
+			setupLogin:     func() {},
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset database for clean state
+			require.NoError(t, container.ResetDatabase(ctx))
+
+			// Setup test data
+			tc.setupLogin()
+
+			// Setup authentication as webmaster
+			sessionID, err := testutils.CreateTestSession(db, "testwebmaster", authorization.ROLE_WEBMASTER.ToString())
+			require.NoError(t, err)
+
+			// Create request
+			req, err := testutils.MakeJSONRequest("DELETE", "/api/v2/logins/"+tc.username, nil)
+			require.NoError(t, err)
+			testutils.SetAuthCookie(req, sessionID)
+
+			// Execute request
+			w := httptest.NewRecorder()
+			apiServer.ServeHTTP(w, req)
+
+			require.Equal(t, tc.expectedStatus, w.Code, "Response: %s", w.Body.String())
+
+			// Verify deletion if successful
+			if tc.expectedStatus == http.StatusNoContent {
+				// Verify login is deleted
+				getReq, err := testutils.MakeJSONRequest("GET", "/api/v2/logins/"+tc.username, nil)
+				require.NoError(t, err)
+				testutils.SetAuthCookie(getReq, sessionID)
+
+				getW := httptest.NewRecorder()
+				apiServer.ServeHTTP(getW, getReq)
+				require.Equal(t, http.StatusNotFound, getW.Code)
+			}
+		})
+	}
+}
+
+func TestChangePassword(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	apiServer := testutils.NewTestAPIServer(db)
+
+	// Test unauthorized/forbidden access
+	testutils.TestInvalidAuthForEndpoint(t, container, apiServer, "PATCH", "/api/v2/logins/testuser/password", loginsUnauthorizedRoles, map[string]any{
+		"newPassword": "newpassword123",
+	})
+
+	testCases := []struct {
+		name                 string
+		username             string
+		setupLogin           func()
+		requestBody          map[string]any
+		expectedStatus       int
+		expectError          bool
+		expectedErrorMessage string
+	}{
+		{
+			name:     "successful password change",
+			username: "alice",
+			setupLogin: func() {
+				db.Create(&models.Login{Username: "alice", Password: "oldhash", Role: "executive"})
+			},
+			requestBody: map[string]any{
+				"newPassword": "newpassword123",
+			},
+			expectedStatus: http.StatusNoContent,
+			expectError:    false,
+		},
+		{
+			name:       "login not found",
+			username:   "nonexistent",
+			setupLogin: func() {},
+			requestBody: map[string]any{
+				"newPassword": "newpassword123",
+			},
+			expectedStatus: http.StatusNotFound,
+			expectError:    true,
+		},
+		{
+			name:     "missing password",
+			username: "alice",
+			setupLogin: func() {
+				db.Create(&models.Login{Username: "alice", Password: "oldhash", Role: "executive"})
+			},
+			requestBody:          map[string]any{},
+			expectedStatus:       http.StatusBadRequest,
+			expectError:          true,
+			expectedErrorMessage: "Key: 'ChangePasswordRequest.NewPassword' Error:Field validation for 'NewPassword' failed on the 'required' tag",
+		},
+		{
+			name:     "password too short",
+			username: "alice",
+			setupLogin: func() {
+				db.Create(&models.Login{Username: "alice", Password: "oldhash", Role: "executive"})
+			},
+			requestBody: map[string]any{
+				"newPassword": "short",
+			},
+			expectedStatus:       http.StatusBadRequest,
+			expectError:          true,
+			expectedErrorMessage: "Key: 'ChangePasswordRequest.NewPassword' Error:Field validation for 'NewPassword' failed on the 'min' tag",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset database for clean state
+			require.NoError(t, container.ResetDatabase(ctx))
+
+			// Setup test data
+			tc.setupLogin()
+
+			// Setup authentication as webmaster
+			sessionID, err := testutils.CreateTestSession(db, "testwebmaster", authorization.ROLE_WEBMASTER.ToString())
+			require.NoError(t, err)
+
+			// Create request
+			req, err := testutils.MakeJSONRequest("PATCH", "/api/v2/logins/"+tc.username+"/password", tc.requestBody)
+			require.NoError(t, err)
+			testutils.SetAuthCookie(req, sessionID)
+
+			// Execute request
+			w := httptest.NewRecorder()
+			apiServer.ServeHTTP(w, req)
+
+			require.Equal(t, tc.expectedStatus, w.Code, "Response: %s", w.Body.String())
+
+			if tc.expectError && tc.expectedErrorMessage != "" {
+				testutils.AssertErrorResponse(t, w, tc.expectedStatus, tc.expectedErrorMessage)
+			}
+		})
+	}
+}

--- a/server/internal/models/login.go
+++ b/server/internal/models/login.go
@@ -11,3 +11,29 @@ type NewSessionRequest struct {
 	Username string `json:"username" binding:"required"`
 	Password string `json:"password" binding:"required"`
 } //@name NewSessionRequest
+
+// LinkedMemberInfo represents the member information linked to a login
+type LinkedMemberInfo struct {
+	ID        uint64 `json:"id"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+} //@name LinkedMemberInfo
+
+// LoginWithMember represents a login with its linked member information
+type LoginWithMember struct {
+	Username     string            `json:"username"`
+	Role         string            `json:"role"`
+	LinkedMember *LinkedMemberInfo `json:"linkedMember"`
+} //@name LoginWithMember
+
+// ChangePasswordRequest represents the request body for changing a password
+type ChangePasswordRequest struct {
+	NewPassword string `json:"newPassword" binding:"required,min=8"`
+} //@name ChangePasswordRequest
+
+// CreateLoginRequest represents the request body for creating a new login
+type CreateLoginRequest struct {
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required,min=8"`
+	Role     string `json:"role" binding:"required,oneof=bot executive tournament_director secretary treasurer vice_president president webmaster"`
+} //@name CreateLoginRequest

--- a/server/internal/server/authentication_handler.go
+++ b/server/internal/server/authentication_handler.go
@@ -5,7 +5,6 @@ import (
 	"api/internal/authorization"
 	e "api/internal/errors"
 	"api/internal/models"
-	"api/internal/services"
 	"net/http"
 	"os"
 	"strings"
@@ -22,24 +21,6 @@ func getCookieKey() string {
 	}
 
 	return "uwpsc-dev-session-id"
-}
-
-func (s *apiServer) CreateLogin(ctx *gin.Context) {
-	var req models.Login
-	err := ctx.ShouldBindJSON(&req)
-	if err != nil {
-		ctx.AbortWithStatusJSON(http.StatusBadRequest, e.InvalidRequest(err.Error()))
-		return
-	}
-
-	svc := services.NewLoginService(s.db)
-	err = svc.CreateLogin(req.Username, req.Password, req.Role)
-	if err != nil {
-		ctx.AbortWithStatusJSON(err.(e.APIErrorResponse).Code, err)
-		return
-	}
-
-	ctx.JSON(http.StatusCreated, "")
 }
 
 func (s *apiServer) SessionLoginHandler(ctx *gin.Context) {

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -68,11 +68,6 @@ func (s *apiServer) SetupRoutes() {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 
-	loginRoute := apiRoute.Group("/login", middleware.UseAuthentication(s.db))
-	{
-		loginRoute.POST("", middleware.UseAuthorization(s.db, "login.create"), s.CreateLogin)
-	}
-
 	sessionRoute := apiRoute.Group("/session")
 	{
 		sessionRoute.POST("", s.SessionLoginHandler)
@@ -160,6 +155,7 @@ func (s *apiServer) SetupV2Routes() {
 		controller.NewMembershipsController(s.db),
 		controller.NewRankingsController(s.db),
 		controller.NewStructuresController(s.db),
+		controller.NewLoginsController(s.db),
 	}
 
 	for _, controller := range controllers {

--- a/server/internal/services/login_service.go
+++ b/server/internal/services/login_service.go
@@ -37,3 +37,123 @@ func (svc *loginService) CreateLogin(username string, password string, role stri
 
 	return nil
 }
+
+// loginWithUserRow is an intermediate struct for scanning LEFT JOIN results
+type loginWithUserRow struct {
+	Username  string
+	Role      string
+	UserID    *uint64
+	FirstName *string
+	LastName  *string
+}
+
+// ListLogins retrieves all logins with their linked member information
+func (svc *loginService) ListLogins() ([]models.LoginWithMember, error) {
+	var rows []loginWithUserRow
+
+	// Use LEFT JOIN to fetch logins with linked members, excluding password
+	err := svc.db.Table("logins").
+		Select("logins.username, logins.role, users.id as user_id, users.first_name, users.last_name").
+		Joins("LEFT JOIN users ON logins.username = users.quest_id").
+		Order("logins.username ASC").
+		Scan(&rows).Error
+
+	if err != nil {
+		return nil, e.InternalServerError(err.Error())
+	}
+
+	// Transform to LoginWithMember
+	results := make([]models.LoginWithMember, len(rows))
+	for i, row := range rows {
+		results[i] = models.LoginWithMember{
+			Username: row.Username,
+			Role:     row.Role,
+		}
+		if row.UserID != nil && *row.UserID != 0 {
+			results[i].LinkedMember = &models.LinkedMemberInfo{
+				ID:        *row.UserID,
+				FirstName: *row.FirstName,
+				LastName:  *row.LastName,
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// GetLogin retrieves a single login by username (without password)
+func (svc *loginService) GetLogin(username string) (*models.LoginWithMember, error) {
+	var row loginWithUserRow
+
+	// Use LEFT JOIN to fetch login with linked member, excluding password
+	err := svc.db.Table("logins").
+		Select("logins.username, logins.role, users.id as user_id, users.first_name, users.last_name").
+		Joins("LEFT JOIN users ON logins.username = users.quest_id").
+		Where("logins.username = ?", username).
+		Scan(&row).Error
+
+	if err != nil {
+		return nil, e.InternalServerError(err.Error())
+	}
+
+	// Check if login was found
+	if row.Username == "" {
+		return nil, e.NotFound("login not found")
+	}
+
+	// Transform to LoginWithMember
+	result := &models.LoginWithMember{
+		Username: row.Username,
+		Role:     row.Role,
+	}
+	if row.UserID != nil && *row.UserID != 0 {
+		result.LinkedMember = &models.LinkedMemberInfo{
+			ID:        *row.UserID,
+			FirstName: *row.FirstName,
+			LastName:  *row.LastName,
+		}
+	}
+
+	return result, nil
+}
+
+// DeleteLogin deletes a login by username
+func (svc *loginService) DeleteLogin(username string) error {
+	// Delete the login and check rows affected (sessions will cascade delete)
+	res := svc.db.Where("username = ?", username).Delete(&models.Login{})
+	if err := res.Error; err != nil {
+		return e.InternalServerError(err.Error())
+	}
+
+	if res.RowsAffected == 0 {
+		return e.NotFound("login not found")
+	}
+
+	return nil
+}
+
+// ChangePassword changes the password for a login
+func (svc *loginService) ChangePassword(username string, newPassword string) error {
+	// Hash the new password
+	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
+	if err != nil {
+		return e.InternalServerError(err.Error())
+	}
+
+	// Update the password and check rows affected
+	res := svc.db.Model(&models.Login{}).Where("username = ?", username).Update("password", string(hash))
+	if err := res.Error; err != nil {
+		return e.InternalServerError(err.Error())
+	}
+
+	if res.RowsAffected == 0 {
+		return e.NotFound("login not found")
+	}
+
+	return nil
+}
+
+// CreateLoginFromRequest creates a new login from a CreateLoginRequest
+func (svc *loginService) CreateLoginFromRequest(req *models.CreateLoginRequest) error {
+	return svc.CreateLogin(req.Username, req.Password, req.Role)
+}

--- a/server/internal/services/login_service_test.go
+++ b/server/internal/services/login_service_test.go
@@ -1,48 +1,414 @@
 package services
 
 import (
+	e "api/internal/errors"
 	"api/internal/database"
 	"api/internal/models"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestLoginService(t *testing.T) {
 	t.Setenv("ENVIRONMENT", "TEST")
 
+	tests := []struct {
+		name string
+		test func(*testing.T)
+	}{
+		{
+			name: "CreateLogin",
+			test: CreateLoginTest,
+		},
+		{
+			name: "ListLogins_Empty",
+			test: ListLoginsEmptyTest,
+		},
+		{
+			name: "ListLogins_Multiple",
+			test: ListLoginsMultipleTest,
+		},
+		{
+			name: "ListLogins_WithLinkedMember",
+			test: ListLoginsWithLinkedMemberTest,
+		},
+		{
+			name: "GetLogin",
+			test: GetLoginTest,
+		},
+		{
+			name: "GetLogin_WithLinkedMember",
+			test: GetLoginWithLinkedMemberTest,
+		},
+		{
+			name: "GetLogin_NotFound",
+			test: GetLoginNotFoundTest,
+		},
+		{
+			name: "DeleteLogin",
+			test: DeleteLoginTest,
+		},
+		{
+			name: "DeleteLogin_NotFound",
+			test: DeleteLoginNotFoundTest,
+		},
+		{
+			name: "ChangePassword",
+			test: ChangePasswordTest,
+		},
+		{
+			name: "ChangePassword_NotFound",
+			test: ChangePasswordNotFoundTest,
+		},
+		{
+			name: "CreateLoginFromRequest",
+			test: CreateLoginFromRequestTest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, tt.test)
+	}
+}
+
+func CreateLoginTest(t *testing.T) {
 	db, err := database.OpenTestConnection()
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	sqlDB, err := db.DB()
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+
+	err = svc.CreateLogin("testuser", "password123", "executive")
+	assert.NoError(t, err)
+
+	// Verify login was created
+	var login models.Login
+	err = db.Where("username = ?", "testuser").First(&login).Error
+	assert.NoError(t, err)
+	assert.Equal(t, "testuser", login.Username)
+	assert.Equal(t, "executive", login.Role)
+
+	// Verify password was hashed
+	err = bcrypt.CompareHashAndPassword([]byte(login.Password), []byte("password123"))
+	assert.NoError(t, err)
+}
+
+func ListLoginsEmptyTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer sqlDB.Close()
+	defer database.WipeDB(db)
 
-	wipeDB := func() {
-		err := database.WipeDB(db)
-		if err != nil {
-			t.Fatal(err.Error())
+	svc := NewLoginService(db)
+
+	// List logins when none exist
+	logins, err := svc.ListLogins()
+	assert.NoError(t, err)
+	assert.Empty(t, logins)
+}
+
+func ListLoginsMultipleTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+
+	// Create test logins
+	err = svc.CreateLogin("alice", "password123", "executive")
+	assert.NoError(t, err)
+	err = svc.CreateLogin("bob", "password456", "president")
+	assert.NoError(t, err)
+	err = svc.CreateLogin("charlie", "password789", "webmaster")
+	assert.NoError(t, err)
+
+	// List logins
+	logins, err := svc.ListLogins()
+	assert.NoError(t, err)
+	assert.Len(t, logins, 3)
+
+	// Verify ordering (alphabetical by username)
+	assert.Equal(t, "alice", logins[0].Username)
+	assert.Equal(t, "bob", logins[1].Username)
+	assert.Equal(t, "charlie", logins[2].Username)
+
+	// Verify roles
+	assert.Equal(t, "executive", logins[0].Role)
+	assert.Equal(t, "president", logins[1].Role)
+	assert.Equal(t, "webmaster", logins[2].Role)
+
+	// Verify no linked members (since we didn't create users)
+	assert.Nil(t, logins[0].LinkedMember)
+	assert.Nil(t, logins[1].LinkedMember)
+	assert.Nil(t, logins[2].LinkedMember)
+}
+
+func ListLoginsWithLinkedMemberTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+	userSvc := NewUserService(db)
+
+	// Create a user with QuestID
+	user, err := userSvc.CreateUser(&models.CreateUserRequest{
+		ID:        12345678,
+		FirstName: "Alice",
+		LastName:  "Smith",
+		Email:     "alice@example.com",
+		Faculty:   "Math",
+		QuestID:   "asmith",
+	})
+	assert.NoError(t, err)
+
+	// Create login matching QuestID
+	err = svc.CreateLogin("asmith", "password123", "executive")
+	assert.NoError(t, err)
+
+	// Create login without matching user
+	err = svc.CreateLogin("webmaster", "password456", "webmaster")
+	assert.NoError(t, err)
+
+	// List logins
+	logins, err := svc.ListLogins()
+	assert.NoError(t, err)
+	assert.Len(t, logins, 2)
+
+	// Find alice login (alphabetically first)
+	var aliceLogin *models.LoginWithMember
+	var webmasterLogin *models.LoginWithMember
+	for i := range logins {
+		if logins[i].Username == "asmith" {
+			aliceLogin = &logins[i]
+		}
+		if logins[i].Username == "webmaster" {
+			webmasterLogin = &logins[i]
 		}
 	}
 
-	loginService := NewLoginService(db)
+	// Verify alice has linked member
+	assert.NotNil(t, aliceLogin)
+	assert.NotNil(t, aliceLogin.LinkedMember)
+	assert.Equal(t, user.ID, aliceLogin.LinkedMember.ID)
+	assert.Equal(t, "Alice", aliceLogin.LinkedMember.FirstName)
+	assert.Equal(t, "Smith", aliceLogin.LinkedMember.LastName)
 
-	t.Run("CreateLogin", func(t *testing.T) {
-		t.Cleanup(wipeDB)
+	// Verify webmaster has no linked member
+	assert.NotNil(t, webmasterLogin)
+	assert.Nil(t, webmasterLogin.LinkedMember)
+}
 
-		err := loginService.CreateLogin("testuser", "testpassword", "president")
-		if assert.NoError(t, err) {
-			var login models.Login
-			err := db.First(&login, "username = ?", "testuser").Error
-			if err != nil {
-				t.Fatal(err.Error())
-			}
-			assert.Equal(t, "testuser", login.Username)
-			assert.NotEmpty(t, login.Password)
-			assert.Equal(t, "president", login.Role)
-		}
+func GetLoginTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+
+	// Create test login
+	err = svc.CreateLogin("alice", "password123", "executive")
+	assert.NoError(t, err)
+
+	// Get login
+	login, err := svc.GetLogin("alice")
+	assert.NoError(t, err)
+	assert.Equal(t, "alice", login.Username)
+	assert.Equal(t, "executive", login.Role)
+	assert.Nil(t, login.LinkedMember)
+}
+
+func GetLoginWithLinkedMemberTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+	userSvc := NewUserService(db)
+
+	// Create user
+	user, err := userSvc.CreateUser(&models.CreateUserRequest{
+		ID:        12345678,
+		FirstName: "Alice",
+		LastName:  "Smith",
+		Email:     "alice@example.com",
+		Faculty:   "Math",
+		QuestID:   "asmith",
 	})
+	assert.NoError(t, err)
+
+	// Create matching login
+	err = svc.CreateLogin("asmith", "password123", "executive")
+	assert.NoError(t, err)
+
+	// Get login
+	login, err := svc.GetLogin("asmith")
+	assert.NoError(t, err)
+	assert.NotNil(t, login.LinkedMember)
+	assert.Equal(t, user.ID, login.LinkedMember.ID)
+	assert.Equal(t, "Alice", login.LinkedMember.FirstName)
+	assert.Equal(t, "Smith", login.LinkedMember.LastName)
+}
+
+func GetLoginNotFoundTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+
+	// Try to get non-existent login
+	_, err = svc.GetLogin("nonexistent")
+	assert.Error(t, err)
+
+	// Verify it's a NotFound error
+	apiErr, ok := err.(e.APIErrorResponse)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+}
+
+func DeleteLoginTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+
+	// Create test login
+	err = svc.CreateLogin("alice", "password123", "executive")
+	assert.NoError(t, err)
+
+	// Verify login exists
+	_, err = svc.GetLogin("alice")
+	assert.NoError(t, err)
+
+	// Delete login
+	err = svc.DeleteLogin("alice")
+	assert.NoError(t, err)
+
+	// Verify login is gone
+	_, err = svc.GetLogin("alice")
+	assert.Error(t, err)
+
+	apiErr, ok := err.(e.APIErrorResponse)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+}
+
+func DeleteLoginNotFoundTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+
+	// Try to delete non-existent login
+	err = svc.DeleteLogin("nonexistent")
+	assert.Error(t, err)
+
+	// Verify it's a NotFound error
+	apiErr, ok := err.(e.APIErrorResponse)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+}
+
+func ChangePasswordTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+
+	// Create test login
+	err = svc.CreateLogin("alice", "oldpassword", "executive")
+	assert.NoError(t, err)
+
+	// Change password
+	err = svc.ChangePassword("alice", "newpassword123")
+	assert.NoError(t, err)
+
+	// Verify password was changed by checking the hash
+	var login models.Login
+	err = db.Where("username = ?", "alice").First(&login).Error
+	assert.NoError(t, err)
+
+	// Verify the new password works
+	err = bcrypt.CompareHashAndPassword([]byte(login.Password), []byte("newpassword123"))
+	assert.NoError(t, err)
+
+	// Verify the old password doesn't work
+	err = bcrypt.CompareHashAndPassword([]byte(login.Password), []byte("oldpassword"))
+	assert.Error(t, err)
+}
+
+func ChangePasswordNotFoundTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+
+	// Try to change password for non-existent login
+	err = svc.ChangePassword("nonexistent", "newpassword")
+	assert.Error(t, err)
+
+	// Verify it's a NotFound error
+	apiErr, ok := err.(e.APIErrorResponse)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+}
+
+func CreateLoginFromRequestTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	svc := NewLoginService(db)
+
+	// Create login from request
+	req := &models.CreateLoginRequest{
+		Username: "alice",
+		Password: "password123",
+		Role:     "executive",
+	}
+	err = svc.CreateLoginFromRequest(req)
+	assert.NoError(t, err)
+
+	// Verify login was created
+	login, err := svc.GetLogin("alice")
+	assert.NoError(t, err)
+	assert.Equal(t, "alice", login.Username)
+	assert.Equal(t, "executive", login.Role)
+
+	// Verify password was hashed correctly
+	var rawLogin models.Login
+	err = db.Where("username = ?", "alice").First(&rawLogin).Error
+	assert.NoError(t, err)
+	err = bcrypt.CompareHashAndPassword([]byte(rawLogin.Password), []byte("password123"))
+	assert.NoError(t, err)
 }

--- a/webapp/src/components/SideNav/SideNav.tsx
+++ b/webapp/src/components/SideNav/SideNav.tsx
@@ -12,6 +12,7 @@ import {
   FaUserTie,
   FaChevronLeft,
   FaChevronRight,
+  FaKey,
 } from "react-icons/fa";
 import logoSvg from "@/assets/uwpsc_logo.svg";
 import crestSvg from "@/assets/crest.svg";
@@ -119,6 +120,27 @@ function SideNav() {
 
               {/* Additional navigation links */}
               <ul className={styles.navLinks}>{renderNavItems(additionalNavItems)}</ul>
+            </>
+          )}
+
+          {hasRoles([ROLES.WEBMASTER]) && (
+            <>
+              {/* Webmaster navigation section with separator */}
+              <div className={styles.navSeparator} data-qa="sidenav-webmaster-section">
+                <span>Webmaster</span>
+              </div>
+
+              {/* Webmaster navigation links */}
+              <ul className={styles.navLinks}>
+                <NavLink
+                  key="/admin/logins"
+                  icon={<FaKey />}
+                  label="Manage Logins"
+                  path="/admin/logins"
+                  isCollapsed={!isExpanded}
+                  onClick={handleNavLinkClick}
+                />
+              </ul>
             </>
           )}
         </div>

--- a/webapp/src/features/logins/api/loginsApi.ts
+++ b/webapp/src/features/logins/api/loginsApi.ts
@@ -1,0 +1,104 @@
+import { sendAPIRequest } from "@/lib/sendAPIRequest";
+import { APIErrorResponse } from "@/types/error";
+import { LoginResponse, CreateLoginRequest, ChangePasswordRequest } from "../types";
+
+/**
+ * Result type for API operations that may fail
+ */
+export type ApiResult<T> = { success: true; data: T } | { success: false; error: string };
+
+/**
+ * Fetch all logins
+ * @returns Array of logins or error
+ */
+export async function fetchLogins(): Promise<ApiResult<LoginResponse[]>> {
+  const { status, data } = await sendAPIRequest<LoginResponse[] | APIErrorResponse>("v2/logins");
+
+  if (status >= 200 && status < 300) {
+    return { success: true, data: (data as LoginResponse[]) ?? [] };
+  }
+
+  const errorResponse = data as APIErrorResponse | undefined;
+  return {
+    success: false,
+    error: errorResponse?.message ?? "Failed to fetch logins",
+  };
+}
+
+/**
+ * Create a new login
+ * @param loginData - Login credentials and role
+ * @returns Created login or error
+ */
+export async function createLogin(loginData: CreateLoginRequest): Promise<ApiResult<LoginResponse>> {
+  const { status, data } = await sendAPIRequest<LoginResponse | APIErrorResponse>(
+    "v2/logins",
+    "POST",
+    loginData as unknown as Record<string, unknown>,
+  );
+
+  if (status === 201) {
+    return { success: true, data: data as LoginResponse };
+  }
+
+  if (status === 409) {
+    return { success: false, error: "Username already exists" };
+  }
+
+  const errorResponse = data as APIErrorResponse | undefined;
+  return {
+    success: false,
+    error: errorResponse?.message ?? "Failed to create login",
+  };
+}
+
+/**
+ * Change password for a login
+ * @param username - Login username to update
+ * @param passwordData - New password
+ * @returns Success or error
+ */
+export async function changePassword(username: string, passwordData: ChangePasswordRequest): Promise<ApiResult<void>> {
+  const { status, data } = await sendAPIRequest<void | APIErrorResponse>(
+    `v2/logins/${username}/password`,
+    "PATCH",
+    passwordData as unknown as Record<string, unknown>,
+  );
+
+  if (status >= 200 && status < 300) {
+    return { success: true, data: undefined };
+  }
+
+  if (status === 404) {
+    return { success: false, error: "Login not found" };
+  }
+
+  const errorResponse = data as APIErrorResponse | undefined;
+  return {
+    success: false,
+    error: errorResponse?.message ?? "Failed to change password",
+  };
+}
+
+/**
+ * Delete a login
+ * @param username - Login username to delete
+ * @returns Success or error
+ */
+export async function deleteLogin(username: string): Promise<ApiResult<void>> {
+  const { status, data } = await sendAPIRequest<void | APIErrorResponse>(`v2/logins/${username}`, "DELETE");
+
+  if (status === 204) {
+    return { success: true, data: undefined };
+  }
+
+  if (status === 404) {
+    return { success: false, error: "Login not found" };
+  }
+
+  const errorResponse = data as APIErrorResponse | undefined;
+  return {
+    success: false,
+    error: errorResponse?.message ?? "Failed to delete login",
+  };
+}

--- a/webapp/src/features/logins/components/CreateLoginModal/CreateLoginModal.module.css
+++ b/webapp/src/features/logins/components/CreateLoginModal/CreateLoginModal.module.css
@@ -1,0 +1,61 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-gray-900, #212121);
+}
+
+.required {
+  color: var(--color-danger, #d93025);
+}
+
+.fieldHint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-gray-500, #9e9e9e);
+}
+
+.errorAlert {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background-color: var(--color-danger-light, #fce8e6);
+  border: 1px solid var(--color-danger, #dc3545);
+  border-radius: 4px;
+  color: var(--color-danger-dark, #a50e0e);
+  font-size: 0.875rem;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .footer {
+    flex-direction: column-reverse;
+  }
+
+  .footer button {
+    width: 100%;
+  }
+}

--- a/webapp/src/features/logins/components/CreateLoginModal/CreateLoginModal.tsx
+++ b/webapp/src/features/logins/components/CreateLoginModal/CreateLoginModal.tsx
@@ -1,0 +1,168 @@
+import { useState, useCallback } from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Modal, Button, useToast, Input, Select } from "@uwpokerclub/components";
+import { createLoginSchema, type CreateLoginFormData, LOGIN_ROLES } from "../../schemas/loginSchemas";
+import { createLogin } from "../../api/loginsApi";
+import styles from "./CreateLoginModal.module.css";
+
+export interface CreateLoginModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function CreateLoginModal({ isOpen, onClose, onSuccess }: CreateLoginModalProps) {
+  const { showToast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const form = useForm<CreateLoginFormData>({
+    resolver: zodResolver(createLoginSchema),
+    defaultValues: {
+      username: "",
+      password: "",
+      role: "" as CreateLoginFormData["role"],
+    },
+  });
+
+  // Reset form when modal closes
+  const handleClose = useCallback(() => {
+    form.reset();
+    setSubmitError(null);
+    onClose();
+  }, [form, onClose]);
+
+  // Handle form submission
+  const handleSubmit = async (data: CreateLoginFormData) => {
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    const result = await createLogin({
+      username: data.username,
+      password: data.password,
+      role: data.role,
+    });
+
+    if (!result.success) {
+      setSubmitError(result.error);
+      showToast({
+        message: result.error,
+        variant: "error",
+        duration: 5000,
+      });
+      setIsSubmitting(false);
+      return;
+    }
+
+    // Success!
+    showToast({
+      message: `Login "${data.username}" created successfully!`,
+      variant: "success",
+      duration: 3000,
+    });
+
+    onSuccess();
+    handleClose();
+    setIsSubmitting(false);
+  };
+
+  // Format role for display
+  const formatRole = (role: string) => {
+    return role
+      .split("_")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+  };
+
+  // Footer with actions
+  const footer = (
+    <div className={styles.footer}>
+      <Button variant="tertiary" onClick={handleClose} disabled={isSubmitting} data-qa="create-login-cancel-btn">
+        Cancel
+      </Button>
+      <Button type="submit" form="create-login-form" disabled={isSubmitting} data-qa="create-login-submit-btn">
+        {isSubmitting ? "Creating..." : "Create Login"}
+      </Button>
+    </div>
+  );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Create Login"
+      size="md"
+      footer={footer}
+      data-qa="create-login-modal"
+    >
+      <div className={styles.content}>
+        {/* Error display */}
+        {submitError && (
+          <div className={styles.errorAlert} data-qa="create-login-error-alert">
+            {submitError}
+          </div>
+        )}
+
+        <FormProvider {...form}>
+          <form id="create-login-form" onSubmit={form.handleSubmit(handleSubmit)} noValidate className={styles.form}>
+            {/* Username Field */}
+            <div className={styles.field}>
+              <label htmlFor="username" className={styles.label}>
+                Username / QuestID <span className={styles.required}>*</span>
+              </label>
+              <Input
+                id="username"
+                data-qa="input-username"
+                type="text"
+                placeholder="e.g., jsmith or j9smith"
+                {...form.register("username")}
+                error={!!form.formState.errors.username}
+                errorMessage={form.formState.errors.username?.message}
+                fullWidth
+              />
+              <p className={styles.fieldHint}>Lowercase letters, numbers, and underscores only</p>
+            </div>
+
+            {/* Password Field */}
+            <div className={styles.field}>
+              <label htmlFor="password" className={styles.label}>
+                Password <span className={styles.required}>*</span>
+              </label>
+              <Input
+                id="password"
+                data-qa="input-password"
+                type="password"
+                placeholder="Minimum 8 characters"
+                {...form.register("password")}
+                error={!!form.formState.errors.password}
+                errorMessage={form.formState.errors.password?.message}
+                fullWidth
+              />
+            </div>
+
+            {/* Role Field */}
+            <div className={styles.field}>
+              <label htmlFor="role" className={styles.label}>
+                Role <span className={styles.required}>*</span>
+              </label>
+              <Select
+                id="role"
+                data-qa="select-role"
+                {...form.register("role")}
+                error={!!form.formState.errors.role}
+                errorMessage={form.formState.errors.role?.message}
+                placeholder="Select a role..."
+                options={LOGIN_ROLES.map((role) => ({
+                  value: role,
+                  label: formatRole(role),
+                }))}
+                fullWidth
+              />
+            </div>
+          </form>
+        </FormProvider>
+      </div>
+    </Modal>
+  );
+}

--- a/webapp/src/features/logins/components/CreateLoginModal/index.ts
+++ b/webapp/src/features/logins/components/CreateLoginModal/index.ts
@@ -1,0 +1,2 @@
+export { CreateLoginModal } from "./CreateLoginModal";
+export type { CreateLoginModalProps } from "./CreateLoginModal";

--- a/webapp/src/features/logins/components/DeleteLoginModal/DeleteLoginModal.module.css
+++ b/webapp/src/features/logins/components/DeleteLoginModal/DeleteLoginModal.module.css
@@ -1,0 +1,26 @@
+.errorAlert {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background-color: var(--color-danger-light, #fce8e6);
+  border: 1px solid var(--color-danger, #dc3545);
+  border-radius: 4px;
+  color: var(--color-danger-dark, #a50e0e);
+  font-size: 0.875rem;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .footer {
+    flex-direction: column-reverse;
+  }
+
+  .footer button {
+    width: 100%;
+  }
+}

--- a/webapp/src/features/logins/components/DeleteLoginModal/DeleteLoginModal.tsx
+++ b/webapp/src/features/logins/components/DeleteLoginModal/DeleteLoginModal.tsx
@@ -1,0 +1,100 @@
+import { Modal, Button, useToast } from "@uwpokerclub/components";
+import { useCallback, useState } from "react";
+import { deleteLogin } from "../../api/loginsApi";
+import { LoginResponse } from "../../types";
+import styles from "./DeleteLoginModal.module.css";
+
+export interface DeleteLoginModalProps {
+  isOpen: boolean;
+  login: LoginResponse | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function DeleteLoginModal({ isOpen, login, onClose, onSuccess }: DeleteLoginModalProps) {
+  const { showToast } = useToast();
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    if (!login) return;
+
+    setIsSubmitting(true);
+    setError("");
+
+    const result = await deleteLogin(login.username);
+
+    if (!result.success) {
+      setError(result.error);
+      showToast({
+        message: result.error,
+        variant: "error",
+        duration: 5000,
+      });
+      setIsSubmitting(false);
+      return;
+    }
+
+    showToast({
+      message: `Login "${login.username}" deleted successfully`,
+      variant: "success",
+      duration: 3000,
+    });
+
+    onSuccess();
+    onClose();
+    setIsSubmitting(false);
+  }, [login, onClose, onSuccess, showToast]);
+
+  const handleClose = useCallback(() => {
+    setError("");
+    onClose();
+  }, [onClose]);
+
+  const footer = (
+    <div className={styles.footer}>
+      <Button variant="tertiary" onClick={handleClose} disabled={isSubmitting} data-qa="delete-login-cancel-btn">
+        Cancel
+      </Button>
+      <Button variant="destructive" onClick={handleSubmit} disabled={isSubmitting} data-qa="delete-login-confirm-btn">
+        {isSubmitting ? "Deleting..." : "Delete Login"}
+      </Button>
+    </div>
+  );
+
+  if (!login) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title="Delete Login"
+      size="md"
+      footer={footer}
+      data-qa="delete-login-modal"
+    >
+      {error && (
+        <div className={styles.errorAlert} role="alert" data-qa="delete-login-error-alert">
+          {error}
+        </div>
+      )}
+      <p>
+        Are you sure you want to delete the login for <strong>{login.username}</strong>?
+      </p>
+      {login.linkedMember && (
+        <p>
+          This login is linked to member{" "}
+          <strong>
+            {login.linkedMember.firstName} {login.linkedMember.lastName}
+          </strong>
+          . The member record will not be affected.
+        </p>
+      )}
+      <p>
+        <strong>This action cannot be undone.</strong> The user will no longer be able to log in with this account.
+      </p>
+    </Modal>
+  );
+}

--- a/webapp/src/features/logins/components/DeleteLoginModal/index.ts
+++ b/webapp/src/features/logins/components/DeleteLoginModal/index.ts
@@ -1,0 +1,2 @@
+export { DeleteLoginModal } from "./DeleteLoginModal";
+export type { DeleteLoginModalProps } from "./DeleteLoginModal";

--- a/webapp/src/features/logins/components/EditPasswordModal/EditPasswordModal.module.css
+++ b/webapp/src/features/logins/components/EditPasswordModal/EditPasswordModal.module.css
@@ -1,0 +1,55 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-gray-900, #212121);
+}
+
+.required {
+  color: var(--color-danger, #d93025);
+}
+
+.errorAlert {
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background-color: var(--color-danger-light, #fce8e6);
+  border: 1px solid var(--color-danger, #dc3545);
+  border-radius: 4px;
+  color: var(--color-danger-dark, #a50e0e);
+  font-size: 0.875rem;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .footer {
+    flex-direction: column-reverse;
+  }
+
+  .footer button {
+    width: 100%;
+  }
+}

--- a/webapp/src/features/logins/components/EditPasswordModal/EditPasswordModal.tsx
+++ b/webapp/src/features/logins/components/EditPasswordModal/EditPasswordModal.tsx
@@ -1,0 +1,155 @@
+import { useState, useCallback, useEffect } from "react";
+import { useForm, FormProvider } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Modal, Button, useToast, Input } from "@uwpokerclub/components";
+import { editPasswordSchema, type EditPasswordFormData } from "../../schemas/loginSchemas";
+import { changePassword } from "../../api/loginsApi";
+import { LoginResponse } from "../../types";
+import styles from "./EditPasswordModal.module.css";
+
+export interface EditPasswordModalProps {
+  isOpen: boolean;
+  login: LoginResponse | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function EditPasswordModal({ isOpen, login, onClose, onSuccess }: EditPasswordModalProps) {
+  const { showToast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const form = useForm<EditPasswordFormData>({
+    resolver: zodResolver(editPasswordSchema),
+    defaultValues: {
+      newPassword: "",
+      confirmPassword: "",
+    },
+  });
+
+  // Reset form when modal opens with new login
+  useEffect(() => {
+    if (isOpen) {
+      form.reset({
+        newPassword: "",
+        confirmPassword: "",
+      });
+      setSubmitError(null);
+    }
+  }, [isOpen, form]);
+
+  // Reset form when modal closes
+  const handleClose = useCallback(() => {
+    form.reset();
+    setSubmitError(null);
+    onClose();
+  }, [form, onClose]);
+
+  // Handle form submission
+  const handleSubmit = async (data: EditPasswordFormData) => {
+    if (!login) return;
+
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    const result = await changePassword(login.username, {
+      newPassword: data.newPassword,
+    });
+
+    if (!result.success) {
+      setSubmitError(result.error);
+      showToast({
+        message: result.error,
+        variant: "error",
+        duration: 5000,
+      });
+      setIsSubmitting(false);
+      return;
+    }
+
+    // Success!
+    showToast({
+      message: `Password for "${login.username}" updated successfully!`,
+      variant: "success",
+      duration: 3000,
+    });
+
+    onSuccess();
+    handleClose();
+    setIsSubmitting(false);
+  };
+
+  // Footer with actions
+  const footer = (
+    <div className={styles.footer}>
+      <Button variant="tertiary" onClick={handleClose} disabled={isSubmitting} data-qa="edit-password-cancel-btn">
+        Cancel
+      </Button>
+      <Button type="submit" form="edit-password-form" disabled={isSubmitting} data-qa="edit-password-submit-btn">
+        {isSubmitting ? "Updating..." : "Update Password"}
+      </Button>
+    </div>
+  );
+
+  if (!login) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={`Edit Password for ${login.username}`}
+      size="md"
+      footer={footer}
+      data-qa="edit-password-modal"
+    >
+      <div className={styles.content}>
+        {/* Error display */}
+        {submitError && (
+          <div className={styles.errorAlert} data-qa="edit-password-error-alert">
+            {submitError}
+          </div>
+        )}
+
+        <FormProvider {...form}>
+          <form id="edit-password-form" onSubmit={form.handleSubmit(handleSubmit)} noValidate className={styles.form}>
+            {/* New Password Field */}
+            <div className={styles.field}>
+              <label htmlFor="newPassword" className={styles.label}>
+                New Password <span className={styles.required}>*</span>
+              </label>
+              <Input
+                id="newPassword"
+                data-qa="input-new-password"
+                type="password"
+                placeholder="Minimum 8 characters"
+                {...form.register("newPassword")}
+                error={!!form.formState.errors.newPassword}
+                errorMessage={form.formState.errors.newPassword?.message}
+                fullWidth
+              />
+            </div>
+
+            {/* Confirm Password Field */}
+            <div className={styles.field}>
+              <label htmlFor="confirmPassword" className={styles.label}>
+                Confirm Password <span className={styles.required}>*</span>
+              </label>
+              <Input
+                id="confirmPassword"
+                data-qa="input-confirm-password"
+                type="password"
+                placeholder="Re-enter new password"
+                {...form.register("confirmPassword")}
+                error={!!form.formState.errors.confirmPassword}
+                errorMessage={form.formState.errors.confirmPassword?.message}
+                fullWidth
+              />
+            </div>
+          </form>
+        </FormProvider>
+      </div>
+    </Modal>
+  );
+}

--- a/webapp/src/features/logins/components/EditPasswordModal/index.ts
+++ b/webapp/src/features/logins/components/EditPasswordModal/index.ts
@@ -1,0 +1,2 @@
+export { EditPasswordModal } from "./EditPasswordModal";
+export type { EditPasswordModalProps } from "./EditPasswordModal";

--- a/webapp/src/features/logins/components/LoginsList/LoginsList.module.css
+++ b/webapp/src/features/logins/components/LoginsList/LoginsList.module.css
@@ -1,0 +1,255 @@
+.container {
+  padding: 1.5rem 2rem;
+}
+
+.tableWrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.searchContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.searchInputWrapper {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex: 1;
+  max-width: 600px;
+}
+
+.clearButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-gray-500, #9e9e9e);
+  cursor: pointer;
+  transition: color 0.2s ease;
+  font-size: 0.875rem;
+}
+
+.clearButton:hover {
+  color: var(--color-gray-700, #616161);
+}
+
+.resultsInfo {
+  color: var(--color-text-secondary, #666);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+}
+
+.resultsInfo p {
+  margin: 0;
+}
+
+/* Action buttons */
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--color-gray-600, #757575);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+  font-size: 1rem;
+}
+
+.iconButton:hover:not(:disabled) {
+  background-color: var(--color-gray-100, #f5f5f5);
+  color: var(--color-gray-900, #212121);
+}
+
+.iconButton.danger {
+  color: var(--color-danger, #d93025);
+}
+
+.iconButton.danger:hover:not(:disabled) {
+  background-color: var(--color-danger-light, #fce8e6);
+  color: var(--color-danger-dark, #a50e0e);
+}
+
+.iconButton:focus-visible {
+  outline: 2px solid var(--color-primary, #f4b80f);
+  outline-offset: 2px;
+}
+
+/* Role badges */
+.roleBadge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+
+.role-webmaster {
+  background-color: #e8f4fd;
+  color: #0c5c8d;
+}
+
+.role-president {
+  background-color: #fef3cd;
+  color: #856404;
+}
+
+.role-vice-president {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.role-treasurer {
+  background-color: #d1ecf1;
+  color: #0c5460;
+}
+
+.role-secretary {
+  background-color: #e2e3e5;
+  color: #383d41;
+}
+
+.role-tournament-director {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+
+.role-executive {
+  background-color: #d6d8db;
+  color: #1b1e21;
+}
+
+.role-bot {
+  background-color: #f5f5f5;
+  color: #666;
+}
+
+/* Linked member display */
+.linkedMember {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.memberId {
+  color: var(--color-gray-500, #9e9e9e);
+  font-size: 0.875rem;
+}
+
+.noLinkedMember {
+  color: var(--color-gray-500, #9e9e9e);
+  font-style: italic;
+}
+
+/* Pagination */
+.paginationContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 2rem;
+}
+
+/* Loading and error states */
+.centerContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  gap: 1rem;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  gap: 1rem;
+  text-align: center;
+}
+
+.emptyIllustration {
+  color: var(--color-gray-300, #e0e0e0);
+  margin-bottom: 1rem;
+}
+
+.emptyState h3 {
+  font-size: 1.5rem;
+  color: var(--color-gray-900, #212121);
+  margin: 0;
+  font-weight: 600;
+}
+
+.emptyState p {
+  font-size: 1rem;
+  color: var(--color-gray-600, #757575);
+  margin: 0;
+  max-width: 400px;
+}
+
+.emptyHint {
+  font-size: 0.875rem !important;
+  color: var(--color-gray-500, #9e9e9e) !important;
+}
+
+.errorState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  gap: 1rem;
+  text-align: center;
+}
+
+.errorState p {
+  color: var(--color-danger, #dc3545);
+  font-size: 1rem;
+  margin: 0;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .container {
+    padding: 1rem 0.5rem 4rem;
+  }
+
+  .searchContainer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .searchInputWrapper {
+    max-width: 100%;
+  }
+
+  .roleBadge {
+    font-size: 0.7rem;
+    padding: 0.2rem 0.6rem;
+  }
+
+  .memberId {
+    font-size: 0.75rem;
+  }
+}

--- a/webapp/src/features/logins/components/LoginsList/LoginsList.tsx
+++ b/webapp/src/features/logins/components/LoginsList/LoginsList.tsx
@@ -1,0 +1,384 @@
+import { useEffect, useState, useMemo, useCallback } from "react";
+import { Table, TableColumn, Button, Input, Pagination, Spinner } from "@uwpokerclub/components";
+import { useAuth } from "@/hooks";
+import { FaEdit, FaTrash, FaSearch, FaPlus, FaTimes, FaKey } from "react-icons/fa";
+import { LoginResponse } from "../../types";
+import { fetchLogins } from "../../api/loginsApi";
+import { CreateLoginModal } from "../CreateLoginModal";
+import { EditPasswordModal } from "../EditPasswordModal";
+import { DeleteLoginModal } from "../DeleteLoginModal";
+import styles from "./LoginsList.module.css";
+
+const ITEMS_PER_PAGE = 25;
+
+export function LoginsList() {
+  const { hasPermission } = useAuth();
+  const [logins, setLogins] = useState<LoginResponse[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [sortKey, setSortKey] = useState<string | undefined>(undefined);
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+
+  // Modal states
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [selectedLogin, setSelectedLogin] = useState<LoginResponse | null>(null);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+
+  // Debounced search query
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery);
+      setCurrentPage(1);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
+
+  // Fetch logins from API
+  useEffect(() => {
+    const loadLogins = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      const result = await fetchLogins();
+
+      if (result.success) {
+        setLogins(result.data);
+      } else {
+        setError(result.error);
+      }
+
+      setIsLoading(false);
+    };
+
+    loadLogins();
+  }, [refreshTrigger]);
+
+  // Filter logins by search query
+  const filteredLogins = useMemo(() => {
+    if (!debouncedSearchQuery.trim()) {
+      return logins;
+    }
+
+    const query = debouncedSearchQuery.toLowerCase();
+    return logins.filter(
+      (login) =>
+        login.username.toLowerCase().includes(query) ||
+        login.role.toLowerCase().includes(query) ||
+        (login.linkedMember &&
+          `${login.linkedMember.firstName} ${login.linkedMember.lastName}`.toLowerCase().includes(query)),
+    );
+  }, [logins, debouncedSearchQuery]);
+
+  // Sort logins
+  const sortedLogins = useMemo(() => {
+    if (!sortKey) {
+      return filteredLogins;
+    }
+
+    const sorted = [...filteredLogins].sort((a, b) => {
+      let aValue: string = "";
+      let bValue: string = "";
+
+      switch (sortKey) {
+        case "username":
+          aValue = a.username.toLowerCase();
+          bValue = b.username.toLowerCase();
+          break;
+        case "role":
+          aValue = a.role.toLowerCase();
+          bValue = b.role.toLowerCase();
+          break;
+        case "linkedMember":
+          aValue = a.linkedMember ? `${a.linkedMember.firstName} ${a.linkedMember.lastName}`.toLowerCase() : "";
+          bValue = b.linkedMember ? `${b.linkedMember.firstName} ${b.linkedMember.lastName}`.toLowerCase() : "";
+          break;
+        default:
+          return 0;
+      }
+
+      if (aValue < bValue) return sortDirection === "asc" ? -1 : 1;
+      if (aValue > bValue) return sortDirection === "asc" ? 1 : -1;
+      return 0;
+    });
+
+    return sorted;
+  }, [filteredLogins, sortKey, sortDirection]);
+
+  // Paginate logins
+  const paginatedLogins = useMemo(() => {
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const endIndex = startIndex + ITEMS_PER_PAGE;
+    return sortedLogins.slice(startIndex, endIndex);
+  }, [sortedLogins, currentPage]);
+
+  // Handle sort
+  const handleSort = useCallback((key: string, direction: "asc" | "desc") => {
+    setSortKey(key);
+    setSortDirection(direction);
+  }, []);
+
+  // Handle clear search
+  const handleClearSearch = () => {
+    setSearchQuery("");
+  };
+
+  // Handle create login
+  const handleCreateLogin = () => {
+    setIsCreateModalOpen(true);
+  };
+
+  // Handle edit password
+  const handleEditPassword = (login: LoginResponse) => {
+    setSelectedLogin(login);
+    setIsEditModalOpen(true);
+  };
+
+  // Handle delete
+  const handleDelete = (login: LoginResponse) => {
+    setSelectedLogin(login);
+    setIsDeleteModalOpen(true);
+  };
+
+  // Handle success callbacks
+  const handleSuccess = () => {
+    setRefreshTrigger((prev) => prev + 1);
+  };
+
+  // Render role badge
+  const renderRoleBadge = (role: string) => {
+    const roleClass = `role-${role.replace("_", "-")}`;
+    const displayRole = role
+      .split("_")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+    return <span className={`${styles.roleBadge} ${styles[roleClass]}`}>{displayRole}</span>;
+  };
+
+  // Render linked member
+  const renderLinkedMember = (linkedMember: LoginResponse["linkedMember"]) => {
+    if (!linkedMember) {
+      return <span className={styles.noLinkedMember}>No linked member</span>;
+    }
+    return (
+      <span className={styles.linkedMember}>
+        {linkedMember.firstName} {linkedMember.lastName}
+        <span className={styles.memberId}>({linkedMember.id})</span>
+      </span>
+    );
+  };
+
+  // Define table columns
+  const columns: TableColumn<LoginResponse>[] = [
+    {
+      key: "username",
+      header: "Username",
+      accessor: "username",
+      sortable: true,
+      headerProps: { "data-qa": "sort-username-header" } as React.ThHTMLAttributes<HTMLTableCellElement>,
+      cellProps: (row) =>
+        ({ "data-qa": `login-username-${row.username}` }) as React.TdHTMLAttributes<HTMLTableCellElement>,
+    },
+    {
+      key: "role",
+      header: "Role",
+      accessor: "role",
+      sortable: true,
+      render: (_value, row) => renderRoleBadge(row.role),
+      headerProps: { "data-qa": "sort-role-header" } as React.ThHTMLAttributes<HTMLTableCellElement>,
+      cellProps: (row) => ({ "data-qa": `login-role-${row.username}` }) as React.TdHTMLAttributes<HTMLTableCellElement>,
+    },
+    {
+      key: "linkedMember",
+      header: "Linked Member",
+      accessor: (row) => (row.linkedMember ? `${row.linkedMember.firstName} ${row.linkedMember.lastName}` : ""),
+      sortable: true,
+      render: (_value, row) => renderLinkedMember(row.linkedMember),
+      headerProps: { "data-qa": "sort-linkedMember-header" } as React.ThHTMLAttributes<HTMLTableCellElement>,
+      cellProps: (row) =>
+        ({ "data-qa": `login-linkedMember-${row.username}` }) as React.TdHTMLAttributes<HTMLTableCellElement>,
+    },
+    {
+      key: "actions",
+      header: "Actions",
+      accessor: () => "",
+      sortable: false,
+      render: (_value, row) => (
+        <div className={styles.actions}>
+          {hasPermission("edit", "login") && (
+            <button
+              className={styles.iconButton}
+              onClick={() => handleEditPassword(row)}
+              title="Edit Password"
+              aria-label="Edit password"
+              data-qa={`edit-password-btn-${row.username}`}
+            >
+              <FaEdit />
+            </button>
+          )}
+          {hasPermission("delete", "login") && (
+            <button
+              className={`${styles.iconButton} ${styles.danger}`}
+              onClick={() => handleDelete(row)}
+              title="Delete Login"
+              aria-label="Delete login"
+              data-qa={`delete-login-btn-${row.username}`}
+            >
+              <FaTrash />
+            </button>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  // Show loading state
+  if (isLoading) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.centerContent} data-qa="logins-loading">
+          <Spinner size="lg" />
+          <p>Loading logins...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Show error state
+  if (error) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.errorState} data-qa="logins-error">
+          <p>Error: {error}</p>
+          <Button data-qa="retry-btn" onClick={() => window.location.reload()}>
+            Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      {/* Search and action bar */}
+      <div className={styles.searchContainer}>
+        <div className={styles.searchInputWrapper}>
+          <Input
+            data-qa="input-logins-search"
+            type="search"
+            placeholder="Search by username or role..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            prefix={<FaSearch />}
+            suffix={
+              searchQuery ? (
+                <button
+                  type="button"
+                  onClick={handleClearSearch}
+                  className={styles.clearButton}
+                  aria-label="Clear search"
+                  data-qa="clear-search-btn"
+                >
+                  <FaTimes />
+                </button>
+              ) : null
+            }
+            fullWidth
+          />
+        </div>
+        {hasPermission("create", "login") && (
+          <Button data-qa="create-login-btn" onClick={handleCreateLogin} iconBefore={<FaPlus />}>
+            Create Login
+          </Button>
+        )}
+      </div>
+
+      <div className={styles.resultsInfo} data-qa="logins-results-info">
+        <p>
+          Showing {paginatedLogins.length} of {sortedLogins.length} logins
+          {debouncedSearchQuery && ` matching "${debouncedSearchQuery}"`}
+        </p>
+      </div>
+
+      {/* Table */}
+      <div className={styles.tableWrapper}>
+        <Table
+          data-qa="logins-table"
+          variant="striped"
+          headerVariant="primary"
+          data={paginatedLogins}
+          columns={columns}
+          sortKey={sortKey}
+          sortDirection={sortDirection}
+          onSort={handleSort}
+          rowProps={(row) => ({ "data-qa": `login-row-${row.username}` }) as React.HTMLAttributes<HTMLTableRowElement>}
+          emptyState={
+            <div className={styles.emptyState}>
+              <div className={styles.emptyIllustration}>
+                <FaKey size={64} />
+              </div>
+              {logins.length === 0 ? (
+                <>
+                  <h3 data-qa="logins-empty">No logins yet</h3>
+                  <p>No login accounts have been created yet.</p>
+                </>
+              ) : (
+                <>
+                  <h3 data-qa="logins-no-results">No results found</h3>
+                  <p>No logins found matching &quot;{debouncedSearchQuery}&quot;</p>
+                  <p className={styles.emptyHint}>Try adjusting your search terms</p>
+                </>
+              )}
+            </div>
+          }
+        />
+      </div>
+
+      {/* Pagination */}
+      {sortedLogins.length > ITEMS_PER_PAGE && (
+        <div className={styles.paginationContainer} data-qa="logins-pagination">
+          <Pagination
+            variant="compact"
+            totalItems={sortedLogins.length}
+            pageSize={ITEMS_PER_PAGE}
+            currentPage={currentPage}
+            onPageChange={setCurrentPage}
+          />
+        </div>
+      )}
+
+      {/* Modals */}
+      <CreateLoginModal
+        isOpen={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
+        onSuccess={handleSuccess}
+      />
+
+      <EditPasswordModal
+        isOpen={isEditModalOpen}
+        login={selectedLogin}
+        onClose={() => {
+          setIsEditModalOpen(false);
+          setSelectedLogin(null);
+        }}
+        onSuccess={handleSuccess}
+      />
+
+      <DeleteLoginModal
+        isOpen={isDeleteModalOpen}
+        login={selectedLogin}
+        onClose={() => {
+          setIsDeleteModalOpen(false);
+          setSelectedLogin(null);
+        }}
+        onSuccess={handleSuccess}
+      />
+    </div>
+  );
+}

--- a/webapp/src/features/logins/components/LoginsList/index.ts
+++ b/webapp/src/features/logins/components/LoginsList/index.ts
@@ -1,0 +1,1 @@
+export { LoginsList } from "./LoginsList";

--- a/webapp/src/features/logins/index.ts
+++ b/webapp/src/features/logins/index.ts
@@ -1,0 +1,7 @@
+export * from "./components/LoginsList";
+export * from "./components/CreateLoginModal";
+export * from "./components/EditPasswordModal";
+export * from "./components/DeleteLoginModal";
+export * from "./pages/LoginsPage";
+export * from "./types";
+export * from "./api/loginsApi";

--- a/webapp/src/features/logins/pages/LoginsPage.module.css
+++ b/webapp/src/features/logins/pages/LoginsPage.module.css
@@ -1,0 +1,37 @@
+.page {
+  width: 100%;
+}
+
+.header {
+  padding: 1.5rem 2rem 1rem;
+  border-bottom: 1px solid var(--color-gray-200, #e0e0e0);
+  background-color: var(--color-background, #ffffff);
+}
+
+.header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--color-gray-900, #212121);
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-gray-600, #757575);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .header {
+    padding: 1rem 0.5rem 0.75rem;
+  }
+
+  .header h1 {
+    font-size: 1.5rem;
+  }
+
+  .subtitle {
+    font-size: 0.85rem;
+  }
+}

--- a/webapp/src/features/logins/pages/LoginsPage.tsx
+++ b/webapp/src/features/logins/pages/LoginsPage.tsx
@@ -1,0 +1,14 @@
+import { LoginsList } from "../components/LoginsList";
+import styles from "./LoginsPage.module.css";
+
+export function LoginsPage() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.header}>
+        <h1>Manage Logins</h1>
+        <p className={styles.subtitle}>Create and manage login accounts for club members and officers</p>
+      </div>
+      <LoginsList />
+    </div>
+  );
+}

--- a/webapp/src/features/logins/schemas/loginSchemas.ts
+++ b/webapp/src/features/logins/schemas/loginSchemas.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { ROLES } from "@/types/roles";
+
+/**
+ * Available roles for login creation (matches backend oneof validation)
+ */
+export const LOGIN_ROLES = [
+  ROLES.BOT,
+  ROLES.EXECUTIVE,
+  ROLES.TOURNAMENT_DIRECTOR,
+  ROLES.SECRETARY,
+  ROLES.TREASURER,
+  ROLES.VICE_PRESIDENT,
+  ROLES.PRESIDENT,
+  ROLES.WEBMASTER,
+] as const;
+
+/**
+ * Role schema with enum validation
+ */
+const roleSchema = z.enum(LOGIN_ROLES, {
+  errorMap: () => ({ message: "Please select a role" }),
+});
+
+/**
+ * Schema for creating a new login
+ */
+export const createLoginSchema = z.object({
+  username: z
+    .string()
+    .min(1, "Username/QuestID is required")
+    .regex(/^[a-z0-9_]+$/, "Username must be lowercase letters, numbers, or underscores only"),
+  password: z
+    .string()
+    .min(8, "Password must be at least 8 characters")
+    .max(128, "Password must not exceed 128 characters"),
+  role: roleSchema,
+});
+
+export type CreateLoginFormData = z.infer<typeof createLoginSchema>;
+
+/**
+ * Schema for editing password with confirmation
+ */
+export const editPasswordSchema = z
+  .object({
+    newPassword: z
+      .string()
+      .min(8, "Password must be at least 8 characters")
+      .max(128, "Password must not exceed 128 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type EditPasswordFormData = z.infer<typeof editPasswordSchema>;

--- a/webapp/src/features/logins/types/index.ts
+++ b/webapp/src/features/logins/types/index.ts
@@ -1,0 +1,35 @@
+import { Role } from "@/types/roles";
+
+/**
+ * Linked member information for display
+ */
+export interface LinkedMember {
+  id: number;
+  firstName: string;
+  lastName: string;
+}
+
+/**
+ * Login response from API (matches backend LoginWithMember)
+ */
+export interface LoginResponse {
+  username: string;
+  role: Role;
+  linkedMember: LinkedMember | null;
+}
+
+/**
+ * Request payload for creating a new login
+ */
+export interface CreateLoginRequest {
+  username: string;
+  password: string;
+  role: Role;
+}
+
+/**
+ * Request payload for changing password
+ */
+export interface ChangePasswordRequest {
+  newPassword: string;
+}

--- a/webapp/src/interfaces/responses/session.ts
+++ b/webapp/src/interfaces/responses/session.ts
@@ -40,7 +40,7 @@ export interface PermissionList {
   event: Pick<Permissions, "create" | "get" | "list" | "edit" | "end" | "restart" | "rebuy"> & {
     participant: Pick<Permissions, "create" | "get" | "list" | "signin" | "signout" | "delete">;
   };
-  login: Pick<Permissions, "create">;
+  login: Pick<Permissions, "create" | "list" | "get" | "edit" | "delete">;
   membership: Pick<Permissions, "create" | "get" | "list" | "edit">;
   semester: Pick<Permissions, "create" | "get" | "list" | "edit"> & {
     rankings: Pick<Permissions, "get" | "list" | "export">;

--- a/webapp/src/pages/Admin.tsx
+++ b/webapp/src/pages/Admin.tsx
@@ -9,6 +9,7 @@ import { Members } from "./Members";
 import { Inventory } from "./Inventory";
 import { Finances } from "./Finances";
 import { Executive } from "./Executive";
+import { Logins } from "./Logins";
 import AdminLayout from "@/layouts/AdminLayout";
 
 export function Admin() {
@@ -25,6 +26,7 @@ export function Admin() {
         <Route path="/inventory" element={<Inventory />} />
         <Route path="/finances" element={<Finances />} />
         <Route path="/executive" element={<Executive />} />
+        <Route path="/logins/*" element={<Logins />} />
       </Routes>
     </AdminLayout>
   );

--- a/webapp/src/pages/Logins.tsx
+++ b/webapp/src/pages/Logins.tsx
@@ -1,0 +1,18 @@
+import { Route, Routes } from "react-router-dom";
+import { RequirePermission } from "@/components";
+import { LoginsPage } from "@/features/logins/pages/LoginsPage";
+
+export function Logins() {
+  return (
+    <Routes>
+      <Route
+        path="/"
+        element={
+          <RequirePermission resource="login" action="list">
+            <LoginsPage />
+          </RequirePermission>
+        }
+      />
+    </Routes>
+  );
+}


### PR DESCRIPTION
## Summary

Add a new webmaster-only page to manage login accounts with full CRUD operations. This feature allows webmasters to view all logins with linked member info, create new logins, change passwords, and delete accounts.

## Changes

### Backend
- Add `LoginService` methods: `ListLogins`, `GetLogin`, `DeleteLogin`, `ChangePassword`
- Add `LoginsController` with REST endpoints for `/api/v2/logins`
- Expand `LoginAuthorizer` with `list`, `get`, `delete`, `edit` permissions (all webmaster-only)
- Remove deprecated `/api/login` route in favor of v2 endpoint
- Add comprehensive unit tests for login service and controller

### Frontend
- Add `LoginsList` component with search, sorting, and pagination
- Add `CreateLoginModal` with username, password, and role fields
- Add `EditPasswordModal` with password confirmation validation
- Add `DeleteLoginModal` with linked member warning
- Add `LoginsPage` and routing configuration at `/admin/logins`
- Add Webmaster section to SideNav (visible only to webmaster role)
- Update `PermissionList` interface with expanded login permissions

### E2E Tests
- Add comprehensive `logins-management.cy.ts` test suite (32 tests)
- Add Webmaster section tests to `sidenav.cy.ts`
- Add login seed data for testing

## Test Plan

- [x] Backend tests pass (`go test -C server ./internal/... -v -p=1`)
- [x] Frontend builds and lints successfully
- [x] E2E tests pass for logins management (32 tests)
- [x] E2E tests pass for sidenav (35 tests including 3 new)
- [ ] Manual testing: navigate to /admin/logins as webmaster
- [ ] Manual testing: create, edit password, and delete logins
- [ ] Manual testing: verify non-webmaster users cannot see Webmaster section