### PR TITLE
Fix escape key closing both nested modals in event registration

### DIFF
--- a/webapp/src/features/events/components/EventRegistrationModal/EventRegistrationModal.tsx
+++ b/webapp/src/features/events/components/EventRegistrationModal/EventRegistrationModal.tsx
@@ -453,6 +453,7 @@ export function EventRegistrationModal({
       onClose={handleClose}
       title="Manage Event Registration"
       size="xl"
+      closeOnEscape={!isCreateMemberModalOpen}
       data-qa="event-registration-modal"
     >
       <div className={styles.modalContent}>


### PR DESCRIPTION
## Summary

Fixes an issue where pressing Escape in the nested "Register Member" modal (opened from Event Registration modal) would close both modals simultaneously and leave UI elements unresponsive.

## Changes

- Add `closeOnEscape={!isCreateMemberModalOpen}` to the parent `EventRegistrationModal`
- This disables escape key handling on the parent modal when the nested modal is open
- Only the topmost modal closes when pressing Escape, parent modal remains functional

## Jira

[UWPSC-48](https://uwpokerclub.atlassian.net/browse/UWPSC-48)

## Test Plan

- [ ] Open Event Registration modal
- [ ] Click "Create New Member" button to open nested modal
- [ ] Press Escape key
- [ ] Verify only the nested modal closes
- [ ] Verify parent modal remains open and functional
- [ ] Verify search bar and buttons remain responsive

[UWPSC-48]: https://uwpokerclub.atlassian.net/browse/UWPSC-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ