### PR TITLE
Use shared database connection pool in session cleanup cron job

### DIFF
--- a/server/cmd/start.go
+++ b/server/cmd/start.go
@@ -35,7 +35,7 @@ var startCmd = &cobra.Command{
 
 		// Initialize cron tasks
 		c := cron.New()
-		c.AddFunc("@daily", cr.SessionCleanup(false))
+		c.AddFunc("@daily", cr.SessionCleanup(db))
 		c.Start()
 
 		// Initialize the server

--- a/server/cron/session_cleanup.go
+++ b/server/cron/session_cleanup.go
@@ -1,10 +1,8 @@
 package cron
 
 import (
-	"api/internal/database"
 	"api/internal/models"
-	"fmt"
-	"os"
+	"log"
 	"time"
 
 	"gorm.io/gorm"
@@ -12,49 +10,13 @@ import (
 
 // SessionCleanup is a cron task that runs daily and will remove all expired sessions from the database. This is
 // meant to preserve space in the database and prevent long standing sessions from taking up most of our database space.
-func SessionCleanup(testing bool) func() {
+func SessionCleanup(db *gorm.DB) func() {
 	return func() {
-		// Open a new database connection, and do not run migrations. When this cron command is initialized the database
-		// migrations will already have been ran, so we do not need to run them again.
-		var db *gorm.DB
-		var err error
-		if !testing {
-			db, err = database.OpenConnection(false)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to open connection to the database: %s", err.Error())
-				os.Exit(1)
-			}
-		} else {
-			db, err = database.OpenTestConnection()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to open connection to the test database: %s", err.Error())
-				os.Exit(1)
-			}
+		res := db.Where("expires_at < ?", time.Now().UTC()).Delete(&models.Session{})
+		if err := res.Error; err != nil {
+			log.Printf("Failed to delete expired sessions from the database: %v", err)
+			return
 		}
-
-		// Close the database connection at the end of this function execution
-		defer func() {
-			sqlDB, err := db.DB()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to retrieve the SQL DB from Gorm: %s", err.Error())
-				os.Exit(1)
-			}
-
-			err = sqlDB.Close()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to close the database: %s", err.Error())
-				os.Exit(1)
-			}
-		}()
-
-		// Get current time
-		now := time.Now().UTC()
-
-		// Delete all expired sessions
-		res := db.Where("expires_at < ?", now.Format("2006-01-02 15:04:05")).Delete(&models.Session{})
-
-		if err = res.Error; err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to delete expired sessions from the database: %s", err.Error())
-		}
+		log.Printf("Session cleanup complete: deleted %d expired session(s)", res.RowsAffected)
 	}
 }


### PR DESCRIPTION
## Summary

The session cleanup cron job (`server/cron/session_cleanup.go`) previously opened a new database connection each time it ran instead of reusing the connection pool established in `start.go`. This wasted resources, risked connection pool exhaustion, and contained dangerous `os.Exit(1)` calls that could prevent graceful shutdown.

## Changes

- Changed `SessionCleanup` signature from `SessionCleanup(testing bool) func()` to `SessionCleanup(db *gorm.DB) func()` to accept the shared connection pool
- Removed all connection open/close logic from the cron job — lifecycle is now managed by `start.go`
- Replaced `os.Exit(1)` calls with `log.Printf` + `return` so a failed cleanup doesn't crash the server
- Simplified the DELETE query to pass `time.Time` directly to GORM instead of string formatting
- Added success log with `RowsAffected` for production observability
- Updated `start.go` to pass the shared `db` instance to the cron job
- Rewrote test to use testcontainers (matching `internal/controller/` pattern) instead of `database.OpenTestConnection()`
- Fixed test assertions to verify session UUIDs instead of usernames
- Removed unnecessary `bcrypt` dependency from the test

## Ticket

[UWPSC-65](https://uwpokerclub.atlassian.net/browse/UWPSC-65)

[UWPSC-65]: https://uwpokerclub.atlassian.net/browse/UWPSC-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ