### PR TITLE
Reuse service instances in middleware instead of creating per request

### DIFF
--- a/server/internal/authorization/authorization_service.go
+++ b/server/internal/authorization/authorization_service.go
@@ -9,14 +9,14 @@ type authorizationService struct {
 	resourceAuthorizers ResourceAuthorizerMap
 }
 
-func NewAuthorizationService(role string, resourceAuthorizers ResourceAuthorizerMap) *authorizationService {
-	return &authorizationService{
+func NewAuthorizationService(role string, resourceAuthorizers ResourceAuthorizerMap) authorizationService {
+	return authorizationService{
 		role:                role,
 		resourceAuthorizers: resourceAuthorizers,
 	}
 }
 
-func (svc *authorizationService) IsAuthorized(action string) bool {
+func (svc authorizationService) IsAuthorized(action string) bool {
 	// Validate input
 	if action == "" {
 		return false
@@ -38,11 +38,11 @@ func (svc *authorizationService) IsAuthorized(action string) bool {
 	return authorizer.IsAuthorized(svc.role, action)
 }
 
-func (svc *authorizationService) Role() string {
+func (svc authorizationService) Role() string {
 	return svc.role
 }
 
-func (svc *authorizationService) GetPermissions() map[string]map[string]any {
+func (svc authorizationService) GetPermissions() map[string]map[string]any {
 	permissions := make(map[string]map[string]any)
 
 	for resource, authorizer := range svc.resourceAuthorizers {

--- a/server/internal/middleware/authentication.go
+++ b/server/internal/middleware/authentication.go
@@ -14,13 +14,16 @@ import (
 )
 
 func UseAuthentication(db *gorm.DB) func(ctx *gin.Context) {
+	var cookieKey string
+	if strings.ToLower(os.Getenv("ENVIRONMENT")) == "production" {
+		cookieKey = "uwpsc-session-id"
+	} else {
+		cookieKey = "uwpsc-dev-session-id"
+	}
+
+	sessionManager := authentication.NewSessionManager(db)
+
 	return func(ctx *gin.Context) {
-		var cookieKey string
-		if strings.ToLower(os.Getenv("ENVIRONMENT")) == "production" {
-			cookieKey = "uwpsc-session-id"
-		} else {
-			cookieKey = "uwpsc-dev-session-id"
-		}
 		cookie, err := ctx.Cookie(cookieKey)
 		if err != nil {
 			// Cookie not present in the request. Return 401
@@ -35,8 +38,6 @@ func UseAuthentication(db *gorm.DB) func(ctx *gin.Context) {
 		}
 
 		sessionID, _ := uuid.Parse(cookie)
-
-		sessionManager := authentication.NewSessionManager(db)
 
 		// Authenticate this session ID
 		session, err := sessionManager.Authenticate(sessionID)

--- a/server/internal/middleware/authorization.go
+++ b/server/internal/middleware/authorization.go
@@ -9,6 +9,8 @@ import (
 )
 
 func UseAuthorization(action string) func(ctx *gin.Context) {
+	authorizerMap := authorization.DefaultAuthorizerMap
+
 	return func(ctx *gin.Context) {
 		role := ctx.GetString("role")
 		if role == "" {
@@ -16,7 +18,7 @@ func UseAuthorization(action string) func(ctx *gin.Context) {
 			return
 		}
 
-		authSvc := authorization.NewAuthorizationService(role, authorization.DefaultAuthorizerMap)
+		authSvc := authorization.NewAuthorizationService(role, authorizerMap)
 
 		authorized := authSvc.IsAuthorized(action)
 		if !authorized {


### PR DESCRIPTION
## Description
Hoist `sessionManager` and `cookieKey` outside the authentication middleware closure so they are created once at init time. Capture `DefaultAuthorizerMap` at authorization middleware init time. Change `authorizationService` to value semantics to enable stack allocation of the per-request struct.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] E2E tests pass
- [ ] Manual testing completed

## Database Changes
- [x] No database changes
- [ ] Migration included and tested
- [ ] Atlas migration generated

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added for new functionality
- [ ] Documentation updated