### PR TITLE
Add TanStack Query infrastructure and shared API client

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.1",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@tanstack/react-query": "^5.99.0",
         "@uwpokerclub/components": "^1.15.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -20,6 +21,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@tanstack/react-query-devtools": "^5.99.0",
         "@types/jest": "^29.5.13",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -2169,6 +2171,61 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
+      "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
+      "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.99.0",
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@tanstack/react-query": "^5.99.0",
     "@uwpokerclub/components": "^1.15.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
@@ -25,6 +26,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^5.99.0",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/webapp/src/lib/QueryProvider.tsx
+++ b/webapp/src/lib/QueryProvider.tsx
@@ -1,0 +1,22 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { ReactNode } from "react";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/webapp/src/lib/apiClient.ts
+++ b/webapp/src/lib/apiClient.ts
@@ -1,0 +1,52 @@
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public type: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+interface RequestOptions {
+  method?: string;
+  body?: Record<string, unknown>;
+}
+
+export async function apiClient<T>(path: string, options: RequestOptions = {}): Promise<T> {
+  const { method = "GET", body } = options;
+
+  const res = await fetch(`${import.meta.env.VITE_API_URL}/${path}`, {
+    credentials: "include",
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (res.status === 401) {
+    window.location.href = "/admin/login";
+    throw new ApiError(401, "unauthorized", "Session expired");
+  }
+
+  if (!res.ok) {
+    let message = "An unexpected error occurred";
+    let type = "unknown";
+
+    try {
+      const errorData = await res.json();
+      message = errorData.message || message;
+      type = errorData.type || type;
+    } catch {
+      /* response may not be JSON */
+    }
+
+    throw new ApiError(res.status, type, message);
+  }
+
+  if (res.status === 204) {
+    return undefined as T;
+  }
+
+  return res.json();
+}

--- a/webapp/src/lib/index.ts
+++ b/webapp/src/lib/index.ts
@@ -1,2 +1,4 @@
+export * from "./apiClient";
+export * from "./QueryProvider";
 export * from "./sendAPIRequest";
 export * from "./sendRequest";

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
+import { QueryProvider } from "./lib/QueryProvider";
 import "@uwpokerclub/components/tokens.css";
 import "@uwpokerclub/components/components.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <QueryProvider>
+      <App />
+    </QueryProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Description
Add TanStack Query (React Query) infrastructure as the foundation for standardizing all data fetching in the webapp. This is the first PR in the UWPSC-74 series.

Introduces:
- `apiClient<T>()` — shared fetch wrapper replacing both `sendAPIRequest` and `sendRequest`, with typed `ApiError`, consistent 401 redirect interceptor, and proper error throwing
- `QueryProvider` — configured `QueryClient` with sensible defaults (`staleTime: 30s`, `retry: 1`) and DevTools enabled in development
- App wrapped with `QueryProvider` in `main.tsx`

No behavioral changes — existing code continues to work as-is. Subsequent PRs will migrate features to use `apiClient` + TanStack Query hooks.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing completed

## Database Changes
- [x] No database changes
- [ ] Migration included and tested
- [ ] Atlas migration generated

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added for new functionality
- [x] Documentation updated