### PR TITLE
Migrate auth/session to TanStack Query

### DIFF
--- a/webapp/src/components/AuthProvider.tsx
+++ b/webapp/src/components/AuthProvider.tsx
@@ -1,139 +1,79 @@
 import { AuthContext } from "@/contexts";
-import { Actions, APIError, Resources, SubResources, UserSession } from "@/interfaces/responses";
+import { Actions, Resources, SubResources } from "@/interfaces/responses";
+import { useSession, useLogin, useLogout, sessionKeys } from "@/hooks/useSessionQuery";
+import { useQueryClient } from "@tanstack/react-query";
 import { Role } from "@/types/roles";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useCallback } from "react";
 
 interface AuthProviderProps {
   children: ReactNode;
 }
 
 export default function AuthProvider({ children }: AuthProviderProps) {
-  const [user, setUser] = useState<UserSession | null>(null);
-  const [error, setError] = useState("");
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
+  const { data: user = null, isLoading, error: queryError } = useSession();
+  const { mutateAsync: doLogin, error: loginError, reset: resetLogin } = useLogin();
+  const { mutateAsync: doLogout, error: logoutError, reset: resetLogout } = useLogout();
 
-  const fetchSession = async (abortSignal: AbortSignal) => {
-    setLoading(true);
+  const login = useCallback(
+    async (username: string, password: string, cb: () => void) => {
+      resetLogout();
+      await doLogin({ username, password });
+      // Wait for session to be fetched before navigating so RequireAuth sees the user
+      await queryClient.invalidateQueries({ queryKey: sessionKeys.current() });
+      cb();
+    },
+    [doLogin, resetLogout, queryClient],
+  );
 
-    try {
-      const response = await fetch("/api/v2/session", {
-        credentials: "include",
-        signal: abortSignal,
-      });
+  const logout = useCallback(
+    async (cb: () => void) => {
+      resetLogin();
+      await doLogout();
+      cb();
+    },
+    [doLogout, resetLogin],
+  );
 
-      if (response.ok) {
-        const data: UserSession = await response.json();
-        setUser(data);
-      } else {
-        const data: APIError = await response.json();
-        setError(data.message);
+  const hasPermission = useCallback(
+    (action: Actions, resource: Resources, subResource?: SubResources) => {
+      if (!user || !user.permissions) {
+        return false;
       }
-    } catch (err) {
-      if (!(err instanceof DOMException && err.name === "AbortError")) {
-        setError("Failed to fetch session. Please contact the webmaster.");
+
+      if (subResource) {
+        const resourcePerm = user.permissions[resource] as { [key: string]: { [key: string]: boolean } };
+        return resourcePerm?.[subResource]?.[action] ?? false;
       }
-    } finally {
-      if (!abortSignal.aborted) {
-        setLoading(false);
+      const resourcePerm = user.permissions[resource] as { [key: string]: boolean };
+      return resourcePerm?.[action] ?? false;
+    },
+    [user],
+  );
+
+  const hasRoles = useCallback(
+    (roles: Role[]) => {
+      if (!user || !user.role) {
+        return false;
       }
-    }
-  };
 
-  const login = async (username: string, password: string, cb: () => void) => {
-    const abortController = new AbortController();
-    setLoading(true);
-    try {
-      const response = await fetch("/api/v2/session", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ username, password }),
-        credentials: "include",
-        signal: abortController.signal,
-      });
+      return roles.some((role) => user.role === role);
+    },
+    [user],
+  );
 
-      if (response.ok) {
-        await fetchSession(abortController.signal);
-
-        cb();
-      } else {
-        const data: APIError = await response.json();
-        setError(data.message);
-      }
-    } catch (err) {
-      if (!(err instanceof DOMException && err.name === "AbortError")) {
-        setError("Network error during login. Please contact the webmaster.");
-      }
-    } finally {
-      if (!abortController.signal.aborted) {
-        setLoading(false);
-      }
-    }
-  };
-
-  const logout = async (cb: () => void) => {
-    setLoading(true);
-    const abortController = new AbortController();
-    try {
-      const response = await fetch("/api/v2/session/logout", {
-        method: "POST",
-        credentials: "include",
-        signal: abortController.signal,
-      });
-
-      if (response.ok) {
-        setUser(null);
-        setError("");
-        cb();
-      }
-    } catch (err) {
-      if (!(err instanceof DOMException && err.name === "AbortError")) {
-        setError("Network error during logout. Please contact the webmaster.");
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const hasPermission = (action: Actions, resource: Resources, subResource?: SubResources) => {
-    if (!user || !user.permissions) {
-      return false;
-    }
-
-    if (subResource) {
-      const resourcePerm = user.permissions[resource] as { [key: string]: { [key: string]: boolean } };
-      return resourcePerm?.[subResource]?.[action] ?? false;
-    }
-    const resourcePerm = user.permissions[resource] as { [key: string]: boolean };
-    return resourcePerm?.[action] ?? false;
-  };
-
-  const hasRoles = (roles: Role[]) => {
-    if (!user || !user.role) {
-      return false;
-    }
-
-    return roles.some((role) => user.role === role);
-  };
+  // Combine query and mutation errors — login errors take priority over stale logout/query errors
+  const error = loginError?.message ?? queryError?.message ?? logoutError?.message ?? "";
 
   const value = {
     user,
-    loading,
+    loading: isLoading,
     error,
     login,
     logout,
     hasPermission,
     hasRoles,
   };
-
-  useEffect(() => {
-    const abortContoller = new AbortController();
-
-    fetchSession(abortContoller.signal);
-
-    return () => abortContoller.abort();
-  }, []);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/webapp/src/components/AuthProvider.tsx
+++ b/webapp/src/components/AuthProvider.tsx
@@ -18,10 +18,14 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   const login = useCallback(
     async (username: string, password: string, cb: () => void) => {
       resetLogout();
-      await doLogin({ username, password });
-      // Wait for session to be fetched before navigating so RequireAuth sees the user
-      await queryClient.invalidateQueries({ queryKey: sessionKeys.current() });
-      cb();
+      try {
+        await doLogin({ username, password });
+        // Wait for session to be fetched before navigating so RequireAuth sees the user
+        await queryClient.invalidateQueries({ queryKey: sessionKeys.current() });
+        cb();
+      } catch {
+        // Error is captured by the mutation state and surfaced via the context error field
+      }
     },
     [doLogin, resetLogout, queryClient],
   );
@@ -29,8 +33,12 @@ export default function AuthProvider({ children }: AuthProviderProps) {
   const logout = useCallback(
     async (cb: () => void) => {
       resetLogin();
-      await doLogout();
-      cb();
+      try {
+        await doLogout();
+        cb();
+      } catch {
+        // Error is captured by the mutation state and surfaced via the context error field
+      }
     },
     [doLogout, resetLogin],
   );

--- a/webapp/src/hooks/useSessionQuery.ts
+++ b/webapp/src/hooks/useSessionQuery.ts
@@ -1,0 +1,68 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient, ApiError } from "@/lib/apiClient";
+import { UserSession } from "@/interfaces/responses";
+
+export const sessionKeys = {
+  all: ["session"] as const,
+  current: () => [...sessionKeys.all, "current"] as const,
+};
+
+async function fetchSession(): Promise<UserSession> {
+  return apiClient<UserSession>("v2/session");
+}
+
+/**
+ * Login uses a direct fetch instead of apiClient because the backend returns
+ * 401 for invalid credentials, and apiClient's 401 interceptor would redirect
+ * to the login page instead of showing the error message.
+ */
+async function loginRequest(credentials: { username: string; password: string }): Promise<void> {
+  const res = await fetch(`${import.meta.env.VITE_API_URL}/v2/session`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(credentials),
+  });
+
+  if (!res.ok) {
+    let message = "An unexpected error occurred";
+    let type = "unknown";
+    try {
+      const errorData = await res.json();
+      message = errorData.message || message;
+      type = errorData.type || type;
+    } catch {
+      /* response may not be JSON */
+    }
+    throw new ApiError(res.status, type, message);
+  }
+}
+
+async function logoutRequest(): Promise<void> {
+  await apiClient<void>("v2/session/logout", { method: "POST" });
+}
+
+export function useSession() {
+  return useQuery({
+    queryKey: sessionKeys.current(),
+    queryFn: fetchSession,
+    retry: false,
+  });
+}
+
+export function useLogin() {
+  return useMutation({
+    mutationFn: loginRequest,
+  });
+}
+
+export function useLogout() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: logoutRequest,
+    onSuccess: () => {
+      queryClient.setQueryData(sessionKeys.current(), null);
+    },
+  });
+}

--- a/webapp/src/hooks/useSessionQuery.ts
+++ b/webapp/src/hooks/useSessionQuery.ts
@@ -7,8 +7,31 @@ export const sessionKeys = {
   current: () => [...sessionKeys.all, "current"] as const,
 };
 
+/**
+ * Session fetch uses direct fetch instead of apiClient because a 401 here
+ * means "not authenticated" — not "session expired mid-use". The 401 redirect
+ * in apiClient would cause an infinite loop on the login page. Instead, the
+ * error is surfaced as a query error and RequireAuth handles the redirect.
+ */
 async function fetchSession(): Promise<UserSession> {
-  return apiClient<UserSession>("v2/session");
+  const res = await fetch(`${import.meta.env.VITE_API_URL}/v2/session`, {
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    let message = "An unexpected error occurred";
+    let type = "unknown";
+    try {
+      const errorData = await res.json();
+      message = errorData.message || message;
+      type = errorData.type || type;
+    } catch {
+      /* response may not be JSON */
+    }
+    throw new ApiError(res.status, type, message);
+  }
+
+  return res.json();
 }
 
 /**


### PR DESCRIPTION
## Description
Migrates the auth/session management from raw fetch+useEffect+useState in `AuthProvider` to TanStack Query hooks. Creates `useSession()`, `useLogin()`, and `useLogout()` hooks that manage session state through the query cache.

Key changes:
- New `useSessionQuery.ts` with session query and login/logout mutations
- `AuthProvider` refactored to use TanStack Query hooks instead of manual fetch+state management
- Login request uses direct `fetch` instead of `apiClient` because the backend returns 401 for bad credentials, and `apiClient`'s 401 interceptor would redirect instead of showing the error message
- `login` callback awaits `invalidateQueries` before calling the navigation callback to prevent a race condition where `RequireAuth` sees stale null user data
- Stale mutation errors are reset cross-wise (login resets logout error and vice versa)
- Stable mutation refs (`mutateAsync`, `reset`) destructured for `useCallback` deps to prevent recreation every render
- Session query uses `retry: false` to avoid retrying 401 responses
- Logout clears session via `setQueryData(null)` to avoid triggering an immediate re-fetch

The `login(username, password, cb)` and `logout(cb)` callback interface is preserved — `LoginPage` and `UserProfile` require no changes.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] E2E tests pass
- [ ] Manual testing completed

## Test Plan
1. Run `npm run build` and `npm run lint` from `webapp/` — both should pass
2. Start the dev server and navigate to `/admin/login`
3. **Login with valid credentials** — verify success redirect to `/admin/dashboard`, session data loads (username/role visible in sidebar)
4. **Login with invalid credentials** — verify error banner appears with "Invalid username or password", no redirect occurs
5. **Login with empty fields** — verify form validation prevents submission
6. **Logout** — click logout in sidebar, verify redirect to `/admin/login`, session is cleared
7. **Session persistence** — after login, refresh the page, verify session is restored and user stays logged in
8. **Session expiry** — clear cookies while on dashboard, trigger any API call, verify redirect to `/admin/login`
9. **TanStack Query DevTools** — verify `["session", "current"]` query appears with session data after login

## Database Changes
- [x] No database changes
- [ ] Migration included and tested
- [ ] Atlas migration generated

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added for new functionality
- [x] Documentation updated