### PR TITLE
refactor(UWPSC-74): migrate members feature to TanStack Query

### DIFF
--- a/webapp/src/features/members/api/memberRegistrationApi.ts
+++ b/webapp/src/features/members/api/memberRegistrationApi.ts
@@ -1,6 +1,6 @@
-import { apiClient } from "../../../lib/apiClient";
-import { User } from "../../../types/user";
-import { Membership } from "../../../types/membership";
+import { apiClient } from "@/lib/apiClient";
+import { User } from "@/types/user";
+import { Membership } from "@/types/membership";
 import type { CreateMemberFormData } from "../validation/registrationSchema";
 
 /**
@@ -126,16 +126,36 @@ export async function deleteMembership(semesterId: string, membershipId: string)
   return apiClient<void>(`v2/semesters/${semesterId}/memberships/${membershipId}`, { method: "DELETE" });
 }
 
+export interface FetchMembershipsParams {
+  limit: number;
+  offset: number;
+  search?: string;
+  studentId?: string;
+  name?: string;
+  email?: string;
+  faculty?: string;
+  paid?: string;
+  discounted?: string;
+}
+
 export async function fetchMemberships(
   semesterId: string,
-  params: { limit: number; offset: number; search?: string },
+  params: FetchMembershipsParams,
 ): Promise<{ data: Membership[]; total: number }> {
-  let query = `?limit=${params.limit}&offset=${params.offset}`;
-  if (params.search) {
-    query += `&search=${encodeURIComponent(params.search)}`;
-  }
+  const query = new URLSearchParams({
+    limit: String(params.limit),
+    offset: String(params.offset),
+  });
+  if (params.search) query.set("search", params.search);
+  if (params.studentId) query.set("studentId", params.studentId);
+  if (params.name) query.set("name", params.name);
+  if (params.email) query.set("email", params.email);
+  if (params.faculty) query.set("faculty", params.faculty);
+  if (params.paid) query.set("paid", params.paid);
+  if (params.discounted) query.set("discounted", params.discounted);
+
   const response = await apiClient<{ data: Membership[]; total: number }>(
-    `v2/semesters/${semesterId}/memberships${query}`,
+    `v2/semesters/${semesterId}/memberships?${query.toString()}`,
   );
   return { data: response.data ?? [], total: response.total ?? 0 };
 }

--- a/webapp/src/features/members/components/DeleteMemberModal/DeleteMemberModal.tsx
+++ b/webapp/src/features/members/components/DeleteMemberModal/DeleteMemberModal.tsx
@@ -1,28 +1,28 @@
 import { Modal, Button, useToast } from "@uwpokerclub/components";
 import { useCallback, useState } from "react";
-import { deleteMember } from "../../api/memberRegistrationApi";
+import { useDeleteMember } from "../../hooks/useMemberQueries";
 import styles from "./DeleteMemberModal.module.css";
 
 export interface DeleteMemberModalProps {
   isOpen: boolean;
   member: { id: string; firstName: string; lastName: string } | null;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess?: () => void;
 }
 
 export function DeleteMemberModal({ isOpen, member, onClose, onSuccess }: DeleteMemberModalProps) {
   const { showToast } = useToast();
   const [error, setError] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const deleteMemberMutation = useDeleteMember();
+  const isSubmitting = deleteMemberMutation.isPending;
 
   const handleSubmit = useCallback(async () => {
     if (!member) return;
 
-    setIsSubmitting(true);
     setError("");
 
     try {
-      await deleteMember(member.id);
+      await deleteMemberMutation.mutateAsync(member.id);
 
       showToast({
         message: `${member.firstName} ${member.lastName} deleted successfully`,
@@ -30,7 +30,7 @@ export function DeleteMemberModal({ isOpen, member, onClose, onSuccess }: Delete
         duration: 3000,
       });
 
-      onSuccess();
+      onSuccess?.();
       onClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to delete member";
@@ -40,14 +40,11 @@ export function DeleteMemberModal({ isOpen, member, onClose, onSuccess }: Delete
         variant: "error",
         duration: 5000,
       });
-    } finally {
-      setIsSubmitting(false);
     }
-  }, [member, onClose, onSuccess, showToast]);
+  }, [member, onClose, onSuccess, showToast, deleteMemberMutation]);
 
   const handleClose = useCallback(() => {
     setError("");
-    setIsSubmitting(false);
     onClose();
   }, [onClose]);
 

--- a/webapp/src/features/members/components/DeleteMembershipModal/DeleteMembershipModal.tsx
+++ b/webapp/src/features/members/components/DeleteMembershipModal/DeleteMembershipModal.tsx
@@ -1,6 +1,6 @@
 import { Modal, Button, useToast } from "@uwpokerclub/components";
 import { useCallback, useState } from "react";
-import { deleteMembership } from "../../api/memberRegistrationApi";
+import { useDeleteMembership } from "../../hooks/useMemberQueries";
 import { Membership } from "@/types";
 import styles from "./DeleteMembershipModal.module.css";
 
@@ -9,7 +9,7 @@ export interface DeleteMembershipModalProps {
   membership: Membership | null;
   semesterId: string;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess?: () => void;
 }
 
 export function DeleteMembershipModal({
@@ -21,16 +21,16 @@ export function DeleteMembershipModal({
 }: DeleteMembershipModalProps) {
   const { showToast } = useToast();
   const [error, setError] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const deleteMembershipMutation = useDeleteMembership();
+  const isSubmitting = deleteMembershipMutation.isPending;
 
   const handleSubmit = useCallback(async () => {
     if (!membership) return;
 
-    setIsSubmitting(true);
     setError("");
 
     try {
-      await deleteMembership(semesterId, membership.id);
+      await deleteMembershipMutation.mutateAsync({ semesterId, membershipId: membership.id });
 
       showToast({
         message: `Membership for ${membership.user.firstName} ${membership.user.lastName} deleted successfully`,
@@ -38,7 +38,7 @@ export function DeleteMembershipModal({
         duration: 3000,
       });
 
-      onSuccess();
+      onSuccess?.();
       onClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to delete membership";
@@ -48,14 +48,11 @@ export function DeleteMembershipModal({
         variant: "error",
         duration: 5000,
       });
-    } finally {
-      setIsSubmitting(false);
     }
-  }, [membership, semesterId, onClose, onSuccess, showToast]);
+  }, [membership, semesterId, onClose, onSuccess, showToast, deleteMembershipMutation]);
 
   const handleClose = useCallback(() => {
     setError("");
-    setIsSubmitting(false);
     onClose();
   }, [onClose]);
 

--- a/webapp/src/features/members/components/EditMemberModal/EditMemberModal.tsx
+++ b/webapp/src/features/members/components/EditMemberModal/EditMemberModal.tsx
@@ -2,21 +2,21 @@ import { useState, useContext, useCallback, useEffect } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Modal, Button, useToast } from "@uwpokerclub/components";
-import { SemesterContext } from "../../../../contexts";
-import { useAuth } from "../../../../hooks";
+import { SemesterContext } from "@/contexts";
+import { useAuth } from "@/hooks";
 import { EditMemberForm } from "./EditMemberForm";
 import { MembershipConfig } from "../RegisterMemberModal/MembershipConfig";
 import { DeleteMemberModal } from "../DeleteMemberModal";
 import { editMemberMembershipSchema, type EditMemberMembershipFormData } from "../../validation/registrationSchema";
-import { updateMember, updateMembership } from "../../api/memberRegistrationApi";
-import type { Membership } from "../../../../types";
+import { useUpdateMember, useUpdateMembership } from "../../hooks/useMemberQueries";
+import type { Membership } from "@/types";
 import styles from "./EditMemberModal.module.css";
 
 export interface EditMemberModalProps {
   isOpen: boolean;
   membership: Membership | null;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess?: () => void;
 }
 
 /**
@@ -26,9 +26,12 @@ export function EditMemberModal({ isOpen, membership, onClose, onSuccess }: Edit
   const semesterContext = useContext(SemesterContext);
   const { showToast } = useToast();
   const { hasPermission } = useAuth();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const updateMemberMutation = useUpdateMember();
+  const updateMembershipMutation = useUpdateMembership();
+  const isSubmitting = updateMemberMutation.isPending || updateMembershipMutation.isPending;
 
   const form = useForm<EditMemberMembershipFormData>({
     resolver: zodResolver(editMemberMembershipSchema),
@@ -81,31 +84,37 @@ export function EditMemberModal({ isOpen, membership, onClose, onSuccess }: Edit
       return;
     }
 
-    setIsSubmitting(true);
     setSubmitError(null);
 
     try {
-      // Update member data
-      await updateMember(String(membership.userId), {
-        firstName: data.member.firstName,
-        lastName: data.member.lastName,
-        email: data.member.email,
-        faculty: data.member.faculty,
-        questId: data.member.questId || "",
-      });
-
-      // Update membership data
-      await updateMembership(semesterContext.currentSemester.id, membership.id, {
-        paid: data.membership.paid,
-        discounted: data.membership.discounted,
-      });
+      await Promise.all([
+        updateMemberMutation.mutateAsync({
+          memberId: String(membership.userId),
+          semesterId: semesterContext.currentSemester.id,
+          data: {
+            firstName: data.member.firstName,
+            lastName: data.member.lastName,
+            email: data.member.email,
+            faculty: data.member.faculty,
+            questId: data.member.questId || "",
+          },
+        }),
+        updateMembershipMutation.mutateAsync({
+          semesterId: semesterContext.currentSemester.id,
+          membershipId: membership.id,
+          data: {
+            paid: data.membership.paid,
+            discounted: data.membership.discounted,
+          },
+        }),
+      ]);
 
       showToast({
         message: `${data.member.firstName} ${data.member.lastName} updated successfully!`,
         variant: "success",
         duration: 3000,
       });
-      onSuccess();
+      onSuccess?.();
       handleClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to update member";
@@ -115,8 +124,6 @@ export function EditMemberModal({ isOpen, membership, onClose, onSuccess }: Edit
         variant: "error",
         duration: 5000,
       });
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -174,7 +181,7 @@ export function EditMemberModal({ isOpen, membership, onClose, onSuccess }: Edit
           onClose={() => setIsDeleteModalOpen(false)}
           onSuccess={() => {
             setIsDeleteModalOpen(false);
-            onSuccess();
+            onSuccess?.();
             handleClose();
           }}
         />

--- a/webapp/src/features/members/components/MembersList.tsx
+++ b/webapp/src/features/members/components/MembersList.tsx
@@ -9,6 +9,7 @@ import { RegisterMemberModal } from "./RegisterMemberModal";
 import { EditMemberModal } from "./EditMemberModal";
 import { DeleteMembershipModal } from "./DeleteMembershipModal";
 import { MemberFilters, type MemberFilterValues } from "./MemberFilters";
+import { useMemberships } from "../hooks/useMemberQueries";
 import styles from "./MembersList.module.css";
 
 const ITEMS_PER_PAGE = 25;
@@ -38,10 +39,6 @@ export function MembersList() {
   const [debouncedFilters, setDebouncedFilters] = useState<MemberFilterValues>(filters);
   const debounceTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  const [members, setMembers] = useState<Membership[]>([]);
-  const [totalItems, setTotalItems] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(() => {
     const page = parseInt(searchParams.get("page") ?? "1", 10);
     return isNaN(page) || page < 1 ? 1 : page;
@@ -52,7 +49,6 @@ export function MembersList() {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedMembership, setSelectedMembership] = useState<Membership | null>(null);
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
 
   // Debounce text filter changes, apply dropdown immediately
@@ -121,50 +117,25 @@ export function MembersList() {
     clearTimeout(debounceTimer.current);
   }, [semesterContext?.currentSemester?.id]);
 
-  // Fetch members from API
-  useEffect(() => {
-    if (!semesterContext?.currentSemester) {
-      setIsLoading(false);
-      return;
-    }
+  const semesterId = semesterContext?.currentSemester?.id;
+  const queryParams = useMemo(
+    () => ({
+      limit: ITEMS_PER_PAGE,
+      offset: (currentPage - 1) * ITEMS_PER_PAGE,
+      ...(debouncedFilters.name && { name: debouncedFilters.name }),
+      ...(debouncedFilters.email && { email: debouncedFilters.email }),
+      ...(debouncedFilters.faculty && { faculty: debouncedFilters.faculty }),
+      ...(debouncedFilters.studentId && { studentId: debouncedFilters.studentId }),
+      ...(debouncedFilters.paid && { paid: debouncedFilters.paid }),
+      ...(debouncedFilters.discounted && { discounted: debouncedFilters.discounted }),
+    }),
+    [currentPage, debouncedFilters],
+  );
 
-    const fetchMembers = async () => {
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const offset = (currentPage - 1) * ITEMS_PER_PAGE;
-        const params = new URLSearchParams({
-          limit: String(ITEMS_PER_PAGE),
-          offset: String(offset),
-        });
-
-        if (debouncedFilters.name) params.set("name", debouncedFilters.name);
-        if (debouncedFilters.email) params.set("email", debouncedFilters.email);
-        if (debouncedFilters.faculty) params.set("faculty", debouncedFilters.faculty);
-        if (debouncedFilters.studentId) params.set("studentId", debouncedFilters.studentId);
-        if (debouncedFilters.paid) params.set("paid", debouncedFilters.paid);
-        if (debouncedFilters.discounted) params.set("discounted", debouncedFilters.discounted);
-
-        const url = `/api/v2/semesters/${semesterContext.currentSemester!.id}/memberships?${params.toString()}`;
-        const response = await fetch(url, { credentials: "include" });
-
-        if (!response.ok) {
-          throw new Error(`Failed to fetch members: ${response.statusText}`);
-        }
-
-        const resp: { data: Membership[]; total: number } = await response.json();
-        setMembers(resp.data);
-        setTotalItems(resp.total);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "An error occurred while fetching members");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchMembers();
-  }, [semesterContext?.currentSemester, refreshTrigger, currentPage, debouncedFilters]);
+  const { data, isLoading, error: queryError } = useMemberships(semesterId, queryParams);
+  const members = useMemo(() => data?.data ?? [], [data]);
+  const totalItems = data?.total ?? 0;
+  const error = queryError?.message ?? null;
 
   // Sort members
   const sortedMembers = useMemo(() => {
@@ -214,10 +185,6 @@ export function MembersList() {
     setIsRegisterModalOpen(true);
   };
 
-  const handleRegistrationSuccess = () => {
-    setRefreshTrigger((prev) => prev + 1);
-  };
-
   const handleViewEdit = (membership: Membership) => {
     setSelectedMembership(membership);
     setIsEditModalOpen(true);
@@ -228,10 +195,6 @@ export function MembersList() {
     setSelectedMembership(null);
   };
 
-  const handleEditSuccess = () => {
-    setRefreshTrigger((prev) => prev + 1);
-  };
-
   const handleDelete = (membership: Membership) => {
     setSelectedMembership(membership);
     setIsDeleteModalOpen(true);
@@ -240,10 +203,6 @@ export function MembersList() {
   const handleDeleteModalClose = () => {
     setIsDeleteModalOpen(false);
     setSelectedMembership(null);
-  };
-
-  const handleDeleteSuccess = () => {
-    setRefreshTrigger((prev) => prev + 1);
   };
 
   const activeFilterCount = Object.values(debouncedFilters).filter((v) => v !== "").length;
@@ -431,19 +390,10 @@ export function MembersList() {
         )}
 
         {/* Register Member Modal */}
-        <RegisterMemberModal
-          isOpen={isRegisterModalOpen}
-          onClose={() => setIsRegisterModalOpen(false)}
-          onSuccess={handleRegistrationSuccess}
-        />
+        <RegisterMemberModal isOpen={isRegisterModalOpen} onClose={() => setIsRegisterModalOpen(false)} />
 
         {/* Edit Member Modal */}
-        <EditMemberModal
-          isOpen={isEditModalOpen}
-          membership={selectedMembership}
-          onClose={handleEditModalClose}
-          onSuccess={handleEditSuccess}
-        />
+        <EditMemberModal isOpen={isEditModalOpen} membership={selectedMembership} onClose={handleEditModalClose} />
 
         {/* Delete Membership Modal */}
         <DeleteMembershipModal
@@ -451,7 +401,6 @@ export function MembersList() {
           membership={selectedMembership}
           semesterId={semesterContext.currentSemester.id}
           onClose={handleDeleteModalClose}
-          onSuccess={handleDeleteSuccess}
         />
       </>
     );

--- a/webapp/src/features/members/components/RegisterMemberModal/RegisterMemberModal.tsx
+++ b/webapp/src/features/members/components/RegisterMemberModal/RegisterMemberModal.tsx
@@ -2,7 +2,7 @@ import { useState, useContext, useCallback } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Modal, Button, useToast } from "@uwpokerclub/components";
-import { SemesterContext } from "../../../../contexts";
+import { SemesterContext } from "@/contexts";
 import { MemberSearch, type SelectedMemberData } from "./MemberSearch";
 import { NewMemberForm } from "./NewMemberForm";
 import { MembershipConfig } from "./MembershipConfig";
@@ -12,7 +12,7 @@ import {
   type SearchModeFormData,
   type CreateModeFormData,
 } from "../../validation/registrationSchema";
-import { createMembership, registerNewMemberWithMembership } from "../../api/memberRegistrationApi";
+import { useCreateMembership, useRegisterNewMemberWithMembership } from "../../hooks/useMemberQueries";
 import styles from "./RegisterMemberModal.module.css";
 
 type Mode = "search" | "create";
@@ -31,7 +31,7 @@ export interface RegisterMemberModalProps {
   isOpen: boolean;
   onClose: () => void;
   /** Called on success. Optionally receives the created membership data. */
-  onSuccess: (data?: RegistrationSuccessData) => void;
+  onSuccess?: (data?: RegistrationSuccessData) => void;
 }
 
 /**
@@ -45,9 +45,12 @@ export function RegisterMemberModal({ isOpen, onClose, onSuccess }: RegisterMemb
   const semesterContext = useContext(SemesterContext);
   const { showToast } = useToast();
   const [mode, setMode] = useState<Mode>("search");
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [selectedMemberName, setSelectedMemberName] = useState<{ firstName: string; lastName: string } | null>(null);
+
+  const createMembershipMutation = useCreateMembership();
+  const registerNewMemberMutation = useRegisterNewMemberWithMembership();
+  const isSubmitting = createMembershipMutation.isPending || registerNewMemberMutation.isPending;
 
   // Search mode form
   const searchForm = useForm<SearchModeFormData>({
@@ -118,16 +121,15 @@ export function RegisterMemberModal({ isOpen, onClose, onSuccess }: RegisterMemb
       return;
     }
 
-    setIsSubmitting(true);
     setSubmitError(null);
 
     try {
-      const membership = await createMembership(
-        semesterContext.currentSemester.id,
-        data.selectedMemberId,
-        data.membership.paid,
-        data.membership.discounted,
-      );
+      const membership = await createMembershipMutation.mutateAsync({
+        semesterId: semesterContext.currentSemester.id,
+        memberId: data.selectedMemberId,
+        paid: data.membership.paid,
+        discounted: data.membership.discounted,
+      });
 
       showToast({
         message: "Member registered successfully!",
@@ -135,7 +137,7 @@ export function RegisterMemberModal({ isOpen, onClose, onSuccess }: RegisterMemb
         duration: 3000,
       });
       searchForm.reset();
-      onSuccess({
+      onSuccess?.({
         membershipId: membership.id,
         userId: membership.userId,
         firstName: selectedMemberName?.firstName ?? membership.user?.firstName ?? "",
@@ -150,8 +152,6 @@ export function RegisterMemberModal({ isOpen, onClose, onSuccess }: RegisterMemb
         variant: "error",
         duration: 5000,
       });
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -162,16 +162,15 @@ export function RegisterMemberModal({ isOpen, onClose, onSuccess }: RegisterMemb
       return;
     }
 
-    setIsSubmitting(true);
     setSubmitError(null);
 
     try {
-      const { member, membership } = await registerNewMemberWithMembership(
-        data.newMember,
-        semesterContext.currentSemester.id,
-        data.membership.paid,
-        data.membership.discounted,
-      );
+      const { member, membership } = await registerNewMemberMutation.mutateAsync({
+        memberData: data.newMember,
+        semesterId: semesterContext.currentSemester.id,
+        paid: data.membership.paid,
+        discounted: data.membership.discounted,
+      });
 
       showToast({
         message: `${member.firstName} ${member.lastName} registered successfully!`,
@@ -179,7 +178,7 @@ export function RegisterMemberModal({ isOpen, onClose, onSuccess }: RegisterMemb
         duration: 3000,
       });
       createForm.reset();
-      onSuccess({
+      onSuccess?.({
         membershipId: membership.id,
         userId: membership.userId,
         firstName: member.firstName,
@@ -193,8 +192,6 @@ export function RegisterMemberModal({ isOpen, onClose, onSuccess }: RegisterMemb
         variant: "error",
         duration: 5000,
       });
-    } finally {
-      setIsSubmitting(false);
     }
   };
 

--- a/webapp/src/features/members/hooks/index.ts
+++ b/webapp/src/features/members/hooks/index.ts
@@ -1,2 +1,13 @@
 export { useMemberSearch } from "./useMemberSearch";
 export type { MemberSearchOption } from "./useMemberSearch";
+export {
+  memberKeys,
+  useMemberships,
+  useCreateMember,
+  useCreateMembership,
+  useRegisterNewMemberWithMembership,
+  useUpdateMember,
+  useUpdateMembership,
+  useDeleteMember,
+  useDeleteMembership,
+} from "./useMemberQueries";

--- a/webapp/src/features/members/hooks/useMemberQueries.ts
+++ b/webapp/src/features/members/hooks/useMemberQueries.ts
@@ -1,0 +1,132 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import {
+  fetchMemberships,
+  createMember,
+  createMembership,
+  registerNewMemberWithMembership,
+  updateMember,
+  updateMembership,
+  deleteMember,
+  deleteMembership,
+  type FetchMembershipsParams,
+  type UpdateMemberRequest,
+  type UpdateMembershipRequest,
+} from "../api/memberRegistrationApi";
+import type { CreateMemberFormData } from "../validation/registrationSchema";
+
+export const memberKeys = {
+  all: ["members"] as const,
+  bySemester: (semesterId: string) => [...memberKeys.all, semesterId] as const,
+  list: (semesterId: string, params: FetchMembershipsParams) => [...memberKeys.bySemester(semesterId), params] as const,
+};
+
+export function useMemberships(semesterId: string | undefined, params: FetchMembershipsParams) {
+  return useQuery({
+    queryKey: memberKeys.list(semesterId ?? "", params),
+    queryFn: () => fetchMemberships(semesterId!, params),
+    enabled: !!semesterId,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useCreateMember() {
+  // No invalidation: a bare member without a membership doesn't appear in any
+  // list; useCreateMembership / useRegisterNewMemberWithMembership handle that.
+  return useMutation({
+    mutationFn: (data: CreateMemberFormData) => createMember(data),
+  });
+}
+
+export function useCreateMembership() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      semesterId,
+      memberId,
+      paid,
+      discounted,
+    }: {
+      semesterId: string;
+      memberId: string;
+      paid: boolean;
+      discounted: boolean;
+    }) => createMembership(semesterId, memberId, paid, discounted),
+    onSuccess: (_data, { semesterId }) => {
+      queryClient.invalidateQueries({ queryKey: memberKeys.bySemester(semesterId) });
+    },
+  });
+}
+
+export function useRegisterNewMemberWithMembership() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      memberData,
+      semesterId,
+      paid,
+      discounted,
+    }: {
+      memberData: CreateMemberFormData;
+      semesterId: string;
+      paid: boolean;
+      discounted: boolean;
+    }) => registerNewMemberWithMembership(memberData, semesterId, paid, discounted),
+    onSuccess: (_data, { semesterId }) => {
+      queryClient.invalidateQueries({ queryKey: memberKeys.bySemester(semesterId) });
+    },
+  });
+}
+
+export function useUpdateMember() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ memberId, data }: { memberId: string; data: UpdateMemberRequest; semesterId?: string }) =>
+      updateMember(memberId, data),
+    onSuccess: (_data, { semesterId }) => {
+      queryClient.invalidateQueries({
+        queryKey: semesterId ? memberKeys.bySemester(semesterId) : memberKeys.all,
+      });
+    },
+  });
+}
+
+export function useUpdateMembership() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      semesterId,
+      membershipId,
+      data,
+    }: {
+      semesterId: string;
+      membershipId: string;
+      data: UpdateMembershipRequest;
+    }) => updateMembership(semesterId, membershipId, data),
+    onSuccess: (_data, { semesterId }) => {
+      queryClient.invalidateQueries({ queryKey: memberKeys.bySemester(semesterId) });
+    },
+  });
+}
+
+export function useDeleteMember() {
+  const queryClient = useQueryClient();
+  // Intentional broad invalidation: a deleted user disappears from every
+  // semester's membership list, so all member-keyed queries must refetch.
+  return useMutation({
+    mutationFn: (memberId: string) => deleteMember(memberId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: memberKeys.all });
+    },
+  });
+}
+
+export function useDeleteMembership() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ semesterId, membershipId }: { semesterId: string; membershipId: string }) =>
+      deleteMembership(semesterId, membershipId),
+    onSuccess: (_data, { semesterId }) => {
+      queryClient.invalidateQueries({ queryKey: memberKeys.bySemester(semesterId) });
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Phase 6 of the TanStack Query migration (UWPSC-74). Converts the **Members feature** from raw `useEffect` + `fetch` + manual `refreshTrigger` state to `useQuery` / `useMutation` with cache invalidation.

- New `useMemberQueries.ts` hooks file with `memberKeys` factory and full CRUD hooks (matches the pattern from entries/events/structures).
- `MembersList.tsx` now uses `useMemberships`; dropped manual fetch, error state, loading state, and `refreshTrigger`.
- All four member modals (Register / Edit / Delete member / Delete membership) switched from direct API calls to mutation hooks. Cache invalidation drives list refresh, so `onSuccess` callbacks became optional.
- `fetchMemberships` extended to accept the full filter set (name, email, faculty, studentId, paid, discounted) — `MembersList` was bypassing it before because it didn't accept those params.
- Member + membership updates in `EditMemberModal` now run concurrently via `Promise.all`.
- `useUpdateMember` accepts an optional `semesterId` so invalidation can scope to one semester instead of blowing away every semester's cache.

## Manual test plan

### Members list

- [x] Navigate to **Members** page — list loads, spinner shows briefly, results render.
- [x] Switch between semesters — list refetches, filters reset, page resets to 1.
- [x] Pagination works; previous-page data stays visible briefly while new page loads (keepPreviousData).
- [x] Filter by name (text) — debounced ~300ms, then list updates and page resets to 1.
- [x] Filter by email, student ID — same debounce behavior.
- [x] Filter by faculty (dropdown) — applies immediately.
- [x] Filter by paid (dropdown) — applies immediately, list updates.
- [x] Filter by discounted (dropdown) — applies immediately.
- [x] Combine multiple filters — all apply, "filter active" badge shows correct count.
- [x] Clear filters — list returns to unfiltered, badge clears.
- [x] Filters + page persist in URL; reload restores them.
- [x] Sort by Student ID / Name / Email / Status — toggles asc/desc.

### Register member modal

- [x] Open modal → defaults to Search mode.
- [x] Search for an existing member by name / email / student ID — dropdown populates.
- [x] Select member, set paid/discounted, submit — toast "Member registered successfully", **list refreshes automatically without page reload**, modal closes.
- [x] Toggle to Create mode → form clears.
- [x] Submit invalid form → field-level errors appear, no API call.
- [x] Submit valid new member → toast with member name, **list refreshes**, modal closes.
- [x] Try to register a duplicate (existing member already in semester) → error toast displays backend message, modal stays open.
- [x] Submit button disabled while in flight ("Registering…").

### Register member modal (used in EventRegistrationModal)

- [x] Open the **event registration** flow → click "Register new member" → submit → confirm `onSuccess` callback still fires (member is auto-added to event entries).

### Edit member modal

- [x] Click edit on a member → form populated with member + membership values.
- [x] Change name/email/faculty/quest ID + paid/discounted → save → toast "X updated successfully", **list refreshes**, modal closes.
- [x] Verify in network tab: PATCH `/api/v2/members/:id` and PATCH `/api/v2/semesters/:sid/memberships/:mid` fire **concurrently** (not sequentially).
- [x] Switch to a different semester after editing — only the current semester's cache invalidates (other tabs would still hit cached data; not directly observable but confirms the scoped invalidation didn't regress UX).
- [x] Submit invalid edit (e.g., empty name) → field error, no API call.
- [x] Cancel button discards changes.

### Delete membership modal

- [x] From edit modal or row action → confirm → toast, **list refreshes**, modal closes.
- [x] Verify the deleted membership disappears from current page.

### Delete member modal

- [x] From the Edit modal danger zone → confirm → toast, edit modal + delete modal both close, **list refreshes**.
- [x] Switch semesters after deletion → deleted member is gone from every semester (broad invalidation is intentional here).

### Error / network handling

- [x] Disconnect network, attempt any mutation → error toast with backend message, modal stays open with error banner, submit button re-enables.
- [x] Permission-restricted user (no `create`/`edit`/`delete`) → action buttons hidden.

### Regression checks

- [x] No console errors during any of the above flows.
- [x] Other features still work: Events list, Event details (entries / clock / structure), Login, Rankings.
- [x] No double-fetch in network tab on initial Members page load.

## Verification

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
