### PR TITLE
refactor(UWPSC-74): migrate logins feature to TanStack Query

### DIFF
--- a/webapp/src/features/logins/api/loginsApi.ts
+++ b/webapp/src/features/logins/api/loginsApi.ts
@@ -1,11 +1,13 @@
 import { apiClient } from "@/lib/apiClient";
 import { LoginResponse, CreateLoginRequest, ChangePasswordRequest } from "../types";
 
-export async function fetchLogins(params: {
+export interface FetchLoginsParams {
   limit: number;
   offset: number;
   search?: string;
-}): Promise<{ data: LoginResponse[]; total: number }> {
+}
+
+export async function fetchLogins(params: FetchLoginsParams): Promise<{ data: LoginResponse[]; total: number }> {
   let query = `?limit=${params.limit}&offset=${params.offset}`;
   if (params.search) {
     query += `&search=${encodeURIComponent(params.search)}`;

--- a/webapp/src/features/logins/components/CreateLoginModal/CreateLoginModal.tsx
+++ b/webapp/src/features/logins/components/CreateLoginModal/CreateLoginModal.tsx
@@ -3,19 +3,20 @@ import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Modal, Button, useToast, Input, Select } from "@uwpokerclub/components";
 import { createLoginSchema, type CreateLoginFormData, LOGIN_ROLES } from "../../schemas/loginSchemas";
-import { createLogin } from "../../api/loginsApi";
+import { useCreateLogin } from "../../hooks/useLoginQueries";
 import styles from "./CreateLoginModal.module.css";
 
 export interface CreateLoginModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess?: () => void;
 }
 
 export function CreateLoginModal({ isOpen, onClose, onSuccess }: CreateLoginModalProps) {
   const { showToast } = useToast();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const createLoginMutation = useCreateLogin();
+  const isSubmitting = createLoginMutation.isPending;
 
   const form = useForm<CreateLoginFormData>({
     resolver: zodResolver(createLoginSchema),
@@ -35,11 +36,10 @@ export function CreateLoginModal({ isOpen, onClose, onSuccess }: CreateLoginModa
 
   // Handle form submission
   const handleSubmit = async (data: CreateLoginFormData) => {
-    setIsSubmitting(true);
     setSubmitError(null);
 
     try {
-      await createLogin({
+      await createLoginMutation.mutateAsync({
         username: data.username,
         password: data.password,
         role: data.role,
@@ -51,7 +51,7 @@ export function CreateLoginModal({ isOpen, onClose, onSuccess }: CreateLoginModa
         duration: 3000,
       });
 
-      onSuccess();
+      onSuccess?.();
       handleClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to create login";
@@ -61,8 +61,6 @@ export function CreateLoginModal({ isOpen, onClose, onSuccess }: CreateLoginModa
         variant: "error",
         duration: 5000,
       });
-    } finally {
-      setIsSubmitting(false);
     }
   };
 

--- a/webapp/src/features/logins/components/DeleteLoginModal/DeleteLoginModal.tsx
+++ b/webapp/src/features/logins/components/DeleteLoginModal/DeleteLoginModal.tsx
@@ -1,6 +1,6 @@
 import { Modal, Button, useToast } from "@uwpokerclub/components";
 import { useCallback, useState } from "react";
-import { deleteLogin } from "../../api/loginsApi";
+import { useDeleteLogin } from "../../hooks/useLoginQueries";
 import { LoginResponse } from "../../types";
 import styles from "./DeleteLoginModal.module.css";
 
@@ -8,22 +8,22 @@ export interface DeleteLoginModalProps {
   isOpen: boolean;
   login: LoginResponse | null;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess?: () => void;
 }
 
 export function DeleteLoginModal({ isOpen, login, onClose, onSuccess }: DeleteLoginModalProps) {
   const { showToast } = useToast();
   const [error, setError] = useState("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const deleteLoginMutation = useDeleteLogin();
+  const isSubmitting = deleteLoginMutation.isPending;
 
   const handleSubmit = useCallback(async () => {
     if (!login) return;
 
-    setIsSubmitting(true);
     setError("");
 
     try {
-      await deleteLogin(login.username);
+      await deleteLoginMutation.mutateAsync(login.username);
 
       showToast({
         message: `Login "${login.username}" deleted successfully`,
@@ -31,7 +31,7 @@ export function DeleteLoginModal({ isOpen, login, onClose, onSuccess }: DeleteLo
         duration: 3000,
       });
 
-      onSuccess();
+      onSuccess?.();
       onClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to delete login";
@@ -41,10 +41,8 @@ export function DeleteLoginModal({ isOpen, login, onClose, onSuccess }: DeleteLo
         variant: "error",
         duration: 5000,
       });
-    } finally {
-      setIsSubmitting(false);
     }
-  }, [login, onClose, onSuccess, showToast]);
+  }, [login, onClose, onSuccess, showToast, deleteLoginMutation]);
 
   const handleClose = useCallback(() => {
     setError("");

--- a/webapp/src/features/logins/components/EditPasswordModal/EditPasswordModal.tsx
+++ b/webapp/src/features/logins/components/EditPasswordModal/EditPasswordModal.tsx
@@ -3,7 +3,7 @@ import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Modal, Button, useToast, Input } from "@uwpokerclub/components";
 import { editPasswordSchema, type EditPasswordFormData } from "../../schemas/loginSchemas";
-import { changePassword } from "../../api/loginsApi";
+import { useChangePassword } from "../../hooks/useLoginQueries";
 import { LoginResponse } from "../../types";
 import styles from "./EditPasswordModal.module.css";
 
@@ -11,13 +11,14 @@ export interface EditPasswordModalProps {
   isOpen: boolean;
   login: LoginResponse | null;
   onClose: () => void;
-  onSuccess: () => void;
+  onSuccess?: () => void;
 }
 
 export function EditPasswordModal({ isOpen, login, onClose, onSuccess }: EditPasswordModalProps) {
   const { showToast } = useToast();
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const changePasswordMutation = useChangePassword();
+  const isSubmitting = changePasswordMutation.isPending;
 
   const form = useForm<EditPasswordFormData>({
     resolver: zodResolver(editPasswordSchema),
@@ -49,12 +50,12 @@ export function EditPasswordModal({ isOpen, login, onClose, onSuccess }: EditPas
   const handleSubmit = async (data: EditPasswordFormData) => {
     if (!login) return;
 
-    setIsSubmitting(true);
     setSubmitError(null);
 
     try {
-      await changePassword(login.username, {
-        newPassword: data.newPassword,
+      await changePasswordMutation.mutateAsync({
+        username: login.username,
+        data: { newPassword: data.newPassword },
       });
 
       showToast({
@@ -63,7 +64,7 @@ export function EditPasswordModal({ isOpen, login, onClose, onSuccess }: EditPas
         duration: 3000,
       });
 
-      onSuccess();
+      onSuccess?.();
       handleClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to change password";
@@ -73,8 +74,6 @@ export function EditPasswordModal({ isOpen, login, onClose, onSuccess }: EditPas
         variant: "error",
         duration: 5000,
       });
-    } finally {
-      setIsSubmitting(false);
     }
   };
 

--- a/webapp/src/features/logins/components/LoginsList/LoginsList.tsx
+++ b/webapp/src/features/logins/components/LoginsList/LoginsList.tsx
@@ -3,7 +3,7 @@ import { Table, TableColumn, Button, Input, Pagination, Spinner } from "@uwpoker
 import { useAuth } from "@/hooks";
 import { FaEdit, FaTrash, FaSearch, FaPlus, FaTimes, FaKey } from "react-icons/fa";
 import { LoginResponse } from "../../types";
-import { fetchLogins } from "../../api/loginsApi";
+import { useLogins } from "../../hooks/useLoginQueries";
 import { CreateLoginModal } from "../CreateLoginModal";
 import { EditPasswordModal } from "../EditPasswordModal";
 import { DeleteLoginModal } from "../DeleteLoginModal";
@@ -13,23 +13,16 @@ const ITEMS_PER_PAGE = 25;
 
 export function LoginsList() {
   const { hasPermission } = useAuth();
-  const [logins, setLogins] = useState<LoginResponse[]>([]);
-  const [totalItems, setTotalItems] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [sortKey, setSortKey] = useState<string | undefined>(undefined);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
 
-  // Modal states
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedLogin, setSelectedLogin] = useState<LoginResponse | null>(null);
-  const [refreshTrigger, setRefreshTrigger] = useState(0);
 
-  // Debounced search query
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
 
   useEffect(() => {
@@ -41,26 +34,19 @@ export function LoginsList() {
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
-  // Fetch logins from API
-  useEffect(() => {
-    const loadLogins = async () => {
-      setIsLoading(true);
-      setError(null);
+  const queryParams = useMemo(
+    () => ({
+      limit: ITEMS_PER_PAGE,
+      offset: (currentPage - 1) * ITEMS_PER_PAGE,
+      ...(debouncedSearchQuery && { search: debouncedSearchQuery }),
+    }),
+    [currentPage, debouncedSearchQuery],
+  );
 
-      try {
-        const offset = (currentPage - 1) * ITEMS_PER_PAGE;
-        const result = await fetchLogins({ limit: ITEMS_PER_PAGE, offset, search: debouncedSearchQuery || undefined });
-        setLogins(result.data);
-        setTotalItems(result.total);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to fetch logins");
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    loadLogins();
-  }, [refreshTrigger, currentPage, debouncedSearchQuery]);
+  const { data, isLoading, error: queryError } = useLogins(queryParams);
+  const logins = useMemo(() => data?.data ?? [], [data]);
+  const totalItems = data?.total ?? 0;
+  const error = queryError?.message ?? null;
 
   // Sort logins
   const sortedLogins = useMemo(() => {
@@ -123,11 +109,6 @@ export function LoginsList() {
   const handleDelete = (login: LoginResponse) => {
     setSelectedLogin(login);
     setIsDeleteModalOpen(true);
-  };
-
-  // Handle success callbacks
-  const handleSuccess = () => {
-    setRefreshTrigger((prev) => prev + 1);
   };
 
   // Render role badge
@@ -333,11 +314,7 @@ export function LoginsList() {
       )}
 
       {/* Modals */}
-      <CreateLoginModal
-        isOpen={isCreateModalOpen}
-        onClose={() => setIsCreateModalOpen(false)}
-        onSuccess={handleSuccess}
-      />
+      <CreateLoginModal isOpen={isCreateModalOpen} onClose={() => setIsCreateModalOpen(false)} />
 
       <EditPasswordModal
         isOpen={isEditModalOpen}
@@ -346,7 +323,6 @@ export function LoginsList() {
           setIsEditModalOpen(false);
           setSelectedLogin(null);
         }}
-        onSuccess={handleSuccess}
       />
 
       <DeleteLoginModal
@@ -356,7 +332,6 @@ export function LoginsList() {
           setIsDeleteModalOpen(false);
           setSelectedLogin(null);
         }}
-        onSuccess={handleSuccess}
       />
     </div>
   );

--- a/webapp/src/features/logins/hooks/useLoginQueries.ts
+++ b/webapp/src/features/logins/hooks/useLoginQueries.ts
@@ -1,0 +1,44 @@
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from "@tanstack/react-query";
+import { fetchLogins, createLogin, changePassword, deleteLogin, type FetchLoginsParams } from "../api/loginsApi";
+import type { CreateLoginRequest, ChangePasswordRequest } from "../types";
+
+export const loginKeys = {
+  all: ["logins"] as const,
+  list: (params: FetchLoginsParams) => [...loginKeys.all, params] as const,
+};
+
+export function useLogins(params: FetchLoginsParams) {
+  return useQuery({
+    queryKey: loginKeys.list(params),
+    queryFn: () => fetchLogins(params),
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useCreateLogin() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateLoginRequest) => createLogin(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: loginKeys.all });
+    },
+  });
+}
+
+export function useChangePassword() {
+  // No invalidation: password changes don't affect any list response.
+  return useMutation({
+    mutationFn: ({ username, data }: { username: string; data: ChangePasswordRequest }) =>
+      changePassword(username, data),
+  });
+}
+
+export function useDeleteLogin() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (username: string) => deleteLogin(username),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: loginKeys.all });
+    },
+  });
+}

--- a/webapp/src/features/logins/index.ts
+++ b/webapp/src/features/logins/index.ts
@@ -5,3 +5,4 @@ export * from "./components/DeleteLoginModal";
 export * from "./pages/LoginsPage";
 export * from "./types";
 export * from "./api/loginsApi";
+export * from "./hooks/useLoginQueries";


### PR DESCRIPTION
## Summary

Phase 7 of the TanStack Query migration (UWPSC-74). Mirrors the Members migration pattern for the **Logins (admin accounts)** feature.

- New `useLoginQueries.ts` hooks file with `loginKeys` factory and `useLogins`, `useCreateLogin`, `useChangePassword`, `useDeleteLogin`.
- `LoginsList.tsx` now uses `useLogins`; dropped manual fetch, error/loading state, and `refreshTrigger`.
- All three modals (`CreateLoginModal`, `EditPasswordModal`, `DeleteLoginModal`) switched from direct API calls to mutation hooks. `onSuccess` callbacks are optional since cache invalidation drives refresh.
- `useChangePassword` intentionally has no invalidation — passwords are not part of any cached list response.
- Promoted the inline `fetchLogins` param shape to `FetchLoginsParams` for consistency with `FetchMembershipsParams`.

## Manual test plan

### Logins list

- [x] Navigate to **Admin → Logins** — list loads, spinner briefly visible on first load.
- [x] Search by username / role / member name — debounced ~300ms, results update, page resets to 1.
- [x] During search, previous results stay visible (no flash of empty state) thanks to `keepPreviousData`.
- [x] Clear search — full list returns.
- [x] Pagination works.
- [x] Sort by Username / Role / Linked Member — toggles asc/desc.
- [x] Empty state: search for nonsense → "No results found" panel.
- [x] Initial empty state (if no logins exist): "No logins yet" panel.

### Create login modal

- [x] Open modal — form is empty, all three fields render.
- [x] Submit invalid form (empty / short password / bad username) → field errors, no API call.
- [x] Create with a valid username + password + role → toast "Login created successfully", **list refreshes automatically**, modal closes.
- [x] Try to create a duplicate username → backend error toast, modal stays open with error banner.
- [x] Submit button shows "Creating…" and disables while in flight.
- [x] Cancel discards the form.

### Edit password modal

- [x] Click edit on a login → modal opens with the username in the title.
- [x] Submit mismatched passwords → field validation error.
- [x] Submit valid password → toast "Password updated successfully", modal closes. (List does **not** refresh — passwords are not displayed; verify no spurious refetch in network tab.)
- [x] Trigger a server error (e.g., very long invalid input) → error toast, modal stays open.

### Delete login modal

- [x] Click delete → confirmation dialog shows username, and "linked member" line if applicable.
- [x] Confirm → toast "Login deleted successfully", **list refreshes**, deleted row disappears.
- [x] Cancel closes without action.
- [x] Try to delete a login while another admin is editing it / a backend error → error toast, modal stays open.

### Error / network handling

- [x] Disconnect network, attempt any mutation → error toast, modal stays open with error banner, submit re-enables.
- [x] Permission-restricted user (no `create`/`edit`/`delete` on `login`) → action buttons hidden.

### Regression checks

- [x] No console errors during any flow above.
- [x] Other features still work: Events list/details, Members, Login page, Rankings.
- [x] No double-fetch in network tab on initial Logins page load.

## Verification

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean