### PR TITLE
Add store package with repository interfaces

### DIFF
--- a/server/internal/store/entry.go
+++ b/server/internal/store/entry.go
@@ -1,0 +1,4 @@
+package store
+
+// EntryRepository is the interface for accessing the entries in the data store. It provides methods for creating, reading, updating, and deleting entries.
+type EntryRepository interface {}

--- a/server/internal/store/event.go
+++ b/server/internal/store/event.go
@@ -1,0 +1,4 @@
+package store
+
+// EventRepository is the interface for accessing the events in the data store. It provides methods for creating, reading, updating, and deleting events.
+type EventRepository interface {}

--- a/server/internal/store/login.go
+++ b/server/internal/store/login.go
@@ -1,0 +1,4 @@
+package store
+
+// LoginRepository is the interface for accessing the logins in the data store. It provides methods for creating, reading, updating, and deleting logins.
+type LoginRepository interface {}

--- a/server/internal/store/member.go
+++ b/server/internal/store/member.go
@@ -1,0 +1,4 @@
+package store
+
+// MemberRepository is the interface for accessing the members in the data store. It provides methods for creating, reading, updating, and deleting logins.
+type MemberRepository interface {}

--- a/server/internal/store/membership.go
+++ b/server/internal/store/membership.go
@@ -1,0 +1,4 @@
+package store
+
+// MembershipRepository is the interface for accessing the memberships in the data store. It provides methods for creating, reading, updating, and deleting memberships.
+type MembershipRepository interface {}

--- a/server/internal/store/ranking.go
+++ b/server/internal/store/ranking.go
@@ -1,0 +1,4 @@
+package store
+
+// RankingRepository is the interface for accessing the rankings in the data store. It provides methods for creating, reading, updating, and deleting rankings.
+type RankingRepository interface {}

--- a/server/internal/store/semester.go
+++ b/server/internal/store/semester.go
@@ -1,0 +1,4 @@
+package store
+
+// SemesterRepository is the interface for accessing the semesters in the data store. It provides methods for creating, reading, updating, and deleting semesters.
+type SemesterRepository interface {}

--- a/server/internal/store/session.go
+++ b/server/internal/store/session.go
@@ -1,0 +1,4 @@
+package store
+
+// SessionRepository is the interface for accessing the sessions in the data store. It provides methods for creating, reading, updating, and deleting sessions.
+type SessionRepository interface {}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -1,0 +1,19 @@
+package store
+
+// Store is the main interface for accessing the data store. It provides methods for accessing the various repositories, as well as methods for managing transactions.
+type Store interface {
+	Semesters() SemesterRepository
+	Members() MemberRepository
+	Memberships() MembershipRepository
+	Events() EventRepository
+	Entries() EntryRepository
+	Rankings() RankingRepository
+	Structures() StructureRepository
+	Logins() LoginRepository
+	Sessions() SessionRepository
+
+	BeginTx() (Store, error)
+	Commit() error
+	Rollback() error
+}
+

--- a/server/internal/store/structure.go
+++ b/server/internal/store/structure.go
@@ -1,0 +1,4 @@
+package store
+
+// StructureRepistory is the interface for accessing the structures in the data store. It provides methods for creating, reading, updating, and deleting structures.
+type StructureRepository interface {}


### PR DESCRIPTION
## Description
Adds the `server/internal/store` package with the `Store` interface and per-entity repository interfaces as the foundation for the store/repository pattern (UWPSC-78 epic).

The `Store` interface provides accessor methods for each repository (`Semesters()`, `Members()`, etc.) and explicit transaction control via `BeginTx()`, `Commit()`, and `Rollback()`. Individual repository interfaces (currently empty stubs) are defined in their own files, ready to have methods added as controllers are migrated.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing completed

## Database Changes
- [x] No database changes
- [ ] Migration included and tested
- [ ] Atlas migration generated

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests added for new functionality
- [x] Documentation updated