### PR TITLE
Add InMemoryStore implementation of store.Store interface

### DIFF
--- a/server/internal/store/inmemory/store.go
+++ b/server/internal/store/inmemory/store.go
@@ -1,0 +1,71 @@
+package inmemory
+
+import (
+	"api/internal/store"
+)
+
+type InMemoryStore struct {
+	semesters store.SemesterRepository
+	memberships store.MembershipRepository
+	members store.MemberRepository
+	events store.EventRepository
+	entries store.EntryRepository
+	rankings store.RankingRepository
+	structures store.StructureRepository
+	logins store.LoginRepository
+	sessions store.SessionRepository
+}
+
+var _ store.Store = (*InMemoryStore)(nil)
+
+func NewStore() store.Store {
+	return &InMemoryStore{}
+}
+
+func (s *InMemoryStore) Semesters() store.SemesterRepository {
+	return s.semesters
+}
+
+func (s *InMemoryStore) Memberships() store.MembershipRepository {
+	return s.memberships
+}
+
+func (s *InMemoryStore) Members() store.MemberRepository {
+	return s.members
+}
+
+func (s *InMemoryStore) Events() store.EventRepository {
+	return s.events
+}
+
+func (s *InMemoryStore) Entries() store.EntryRepository {
+	return s.entries
+}
+
+func (s *InMemoryStore) Rankings() store.RankingRepository {
+	return s.rankings
+}
+
+func (s *InMemoryStore) Structures() store.StructureRepository {
+	return s.structures
+}
+
+func (s *InMemoryStore) Logins() store.LoginRepository {
+	return s.logins
+}
+
+func (s *InMemoryStore) Sessions() store.SessionRepository {
+	return s.sessions
+}
+
+func (s *InMemoryStore) BeginTx() (store.Store, error) {
+	return s, nil
+}
+
+func (s *InMemoryStore) Commit() error {
+	return nil
+}
+
+func (s *InMemoryStore) Rollback() error {
+	return nil
+}


### PR DESCRIPTION
## Description
Adds `InMemoryStore`, an in-memory implementation of the `store.Store` interface for use in unit tests. This avoids the need for a real database in tests that don't require integration-level coverage.

> Note: this PR is stacked on #308 (PostgresStore). The diff includes those changes as master doesn't have them yet.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [x] E2E tests pass
- [x] Manual testing completed

## Database Changes
- [x] No database changes
- [ ] Migration included and tested
- [ ] Atlas migration generated

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added for new functionality
- [ ] Documentation updated