### PR TITLE
Implement StructureRepository and migrate structures controller to store

### DIFF
--- a/server/atlas/migrations/20260615020338.sql
+++ b/server/atlas/migrations/20260615020338.sql
@@ -1,0 +1,2 @@
+-- Modify "blinds" table
+ALTER TABLE "blinds" DROP CONSTRAINT "fk_structures_blinds", ADD CONSTRAINT "fk_structures_blinds" FOREIGN KEY ("structure_id") REFERENCES "structures" ("id") ON UPDATE CASCADE ON DELETE CASCADE;

--- a/server/atlas/migrations/20260615021753.sql
+++ b/server/atlas/migrations/20260615021753.sql
@@ -1,0 +1,2 @@
+-- Modify "events" table
+ALTER TABLE "events" DROP CONSTRAINT "fk_events_structure", ADD CONSTRAINT "fk_events_structure" FOREIGN KEY ("structure_id") REFERENCES "structures" ("id") ON UPDATE CASCADE ON DELETE CASCADE;

--- a/server/atlas/migrations/atlas.sum
+++ b/server/atlas/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:XDSUnmHowzUPcARaeM91dMt1MlskBBDb2WS7bmD2Pec=
+h1:cHVTPiZlgCb2cEnlCZahdwC7l3Nc1fKAnXXt6dDeQhE=
 20250726011345.sql h1:4dL9LFflDQg37iMgIkc+JUOX/z480+aElFRGbuoV3EU=
 20250817202601.sql h1:gdsNY4AamlxHbsdTWRaa3grcW4SyT8RsiQtI/kDLUtk=
 20250817202602.sql h1:MD7NWzakA9fmNWSMrVwMFNud82zrzCyYsYwJWPHn79w=
@@ -9,3 +9,5 @@ h1:XDSUnmHowzUPcARaeM91dMt1MlskBBDb2WS7bmD2Pec=
 20260207181318_backfill_session_roles.sql h1:ofW8bkgfEpiRtJ0k7caKN1Gjq+oF4TeDNFYBjOcepks=
 20260214014118_restructure_participants_pk.sql h1:6DZNnzk30ipy26k0oFt1FY/mavg37XC0LzI0IHqfpgk=
 20260214034829.sql h1:k2i0Pt5gJJQjBYluyRyOm1aEi/eJCELQDhok4PxHZ+E=
+20260615020338.sql h1:J7KDtZ/MS5eyS7t2rMwE/NjF33BsEvwRMqzXB8jcg+o=
+20260615021753.sql h1:tNePbUAxv/KXtTfnvjV2cdmpb33Pk/aC/GyJU9lZf/0=

--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -2532,12 +2532,6 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -2524,12 +2524,6 @@
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -2128,10 +2128,6 @@ paths:
           description: Forbidden
           schema:
             $ref: '#/definitions/ErrorResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/ErrorResponse'
         "500":
           description: Internal Server Error
           schema:

--- a/server/go.sum
+++ b/server/go.sum
@@ -668,6 +668,8 @@ github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
+github.com/alecthomas/kong v1.9.0 h1:Wgg0ll5Ys7xDnpgYBuBn/wPeLGAuK0NvYmEcisJgrIs=
+github.com/alecthomas/kong v1.9.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=

--- a/server/internal/controller/members.go
+++ b/server/internal/controller/members.go
@@ -152,7 +152,7 @@ func (c *membersController) listMembers(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, models.ListResponse[*models.User]{
+	ctx.JSON(http.StatusOK, models.ListResponse[models.User]{
 		Data:  members,
 		Total: total,
 	})
@@ -266,7 +266,7 @@ func (c *membersController) updateMember(ctx *gin.Context) {
 		member.QuestID = req.QuestID
 	}
 
-	if err := tx.Members().Update(member); err != nil {
+	if err := tx.Members().Update(&member); err != nil {
 		ctx.AbortWithStatusJSON(
 			http.StatusInternalServerError,
 			apierrors.InternalServerError(err.Error()),
@@ -282,7 +282,16 @@ func (c *membersController) updateMember(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, member)
+	result, err := c.store.Members().FindByID(memberID)
+	if err != nil {
+		ctx.AbortWithStatusJSON(
+			http.StatusInternalServerError,
+			apierrors.InternalServerError(err.Error()),
+		)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, result)
 }
 
 // deleteMember handles deleting a Member by ID

--- a/server/internal/controller/semesters.go
+++ b/server/internal/controller/semesters.go
@@ -96,7 +96,7 @@ func (s *semestersController) listSemesters(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, models.ListResponse[*models.Semester]{
+	ctx.JSON(http.StatusOK, models.ListResponse[models.Semester]{
 		Data:  semesters,
 		Total: total,
 	})

--- a/server/internal/controller/structures.go
+++ b/server/internal/controller/structures.go
@@ -4,7 +4,7 @@ import (
 	apierrors "api/internal/errors"
 	"api/internal/middleware"
 	"api/internal/models"
-	"api/internal/services"
+	"api/internal/store"
 	"errors"
 	"fmt"
 	"net/http"
@@ -16,10 +16,11 @@ import (
 
 type structuresController struct {
 	db *gorm.DB
+  store store.Store
 }
 
-func NewStructuresController(db *gorm.DB) Controller {
-	return &structuresController{db: db}
+func NewStructuresController(db *gorm.DB, store store.Store) Controller {
+  return &structuresController{db: db, store: store}
 }
 
 func (s *structuresController) LoadRoutes(router *gin.RouterGroup) {
@@ -51,8 +52,7 @@ func (s *structuresController) listStructures(ctx *gin.Context) {
 		return
 	}
 
-	svc := services.NewStructureService(s.db)
-	structures, total, err := svc.ListStructuresV2(&pagination)
+  structures, total, err := s.store.Structures().List(&pagination)
 	if err != nil {
 		ctx.AbortWithStatusJSON(
 			http.StatusInternalServerError,
@@ -88,9 +88,23 @@ func (s *structuresController) createStructure(ctx *gin.Context) {
 		return
 	}
 
-	svc := services.NewStructureService(s.db)
-	structure, err := svc.CreateStructure(&req)
-	if err != nil {
+  blinds := make([]models.Blind, len(req.Blinds))
+  for i, blind := range req.Blinds {
+    blinds[i] = models.Blind{
+      Small: blind.Small,
+      Big:   blind.Big,
+      Ante:  blind.Ante,
+      Time:  blind.Time,
+      Index: int8(i),
+    }
+  }
+
+  structure := models.Structure{
+    Name: req.Name,
+    Blinds: blinds,
+  }
+
+  if err := s.store.Structures().Create(&structure); err != nil {
 		ctx.AbortWithStatusJSON(
 			http.StatusInternalServerError,
 			apierrors.InternalServerError(err.Error()),
@@ -124,11 +138,10 @@ func (s *structuresController) getStructure(ctx *gin.Context) {
 		return
 	}
 
-	svc := services.NewStructureService(s.db)
-	structure, err := svc.GetStructure(id)
+  structure, err := s.store.Structures().FindByID(id)
 	if err != nil {
-		if apiErr, ok := err.(apierrors.APIErrorResponse); ok {
-			ctx.AbortWithStatusJSON(apiErr.Code, apiErr)
+		if errors.Is(err, store.ErrNotFound) {
+			ctx.AbortWithStatusJSON(http.StatusNotFound, apierrors.NotFound(err.Error()))
 			return
 		}
 		ctx.AbortWithStatusJSON(
@@ -172,28 +185,75 @@ func (s *structuresController) updateStructure(ctx *gin.Context) {
 
 	updateMap, err := s.validateAndCreateStructureUpdateMap(requestValues)
 	if err != nil {
-		ctx.AbortWithStatusJSON(
-			http.StatusBadRequest,
-			apierrors.InvalidRequest(err.Error()),
-		)
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, apierrors.InvalidRequest(err.Error()))
 		return
 	}
 
-	svc := services.NewStructureService(s.db)
-	structure, err := svc.UpdateStructureV2(id, updateMap)
+	tx, err := s.store.BeginTx()
 	if err != nil {
-		if apiErr, ok := err.(apierrors.APIErrorResponse); ok {
-			ctx.AbortWithStatusJSON(apiErr.Code, apiErr)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, apierrors.InternalServerError(err.Error()))
+		return
+	}
+	defer tx.Rollback()
+
+	structure, err := tx.Structures().FindByID(id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			ctx.AbortWithStatusJSON(http.StatusNotFound, apierrors.NotFound("Structure not found"))
 			return
 		}
-		ctx.AbortWithStatusJSON(
-			http.StatusInternalServerError,
-			apierrors.InternalServerError(err.Error()),
-		)
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, apierrors.InternalServerError(err.Error()))
 		return
 	}
 
-	ctx.JSON(http.StatusOK, structure)
+	if len(updateMap) == 0 {
+		ctx.JSON(http.StatusOK, structure)
+		return
+	}
+
+	if name, ok := updateMap["name"]; ok {
+		structure.Name = name.(string)
+		if err := tx.Structures().Update(&structure); err != nil {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, apierrors.InternalServerError(err.Error()))
+			return
+		}
+	}
+
+	if blindsData, ok := updateMap["blinds"]; ok {
+		blindsJSON := blindsData.([]models.BlindJSON)
+		blinds := make([]models.Blind, len(blindsJSON))
+		for i, b := range blindsJSON {
+			blinds[i] = models.Blind{
+				Small:       b.Small,
+				Big:         b.Big,
+				Ante:        b.Ante,
+				Time:        b.Time,
+				StructureId: id,
+				Index:       int8(i),
+			}
+		}
+		if err := tx.Structures().ReplaceBlindsByStructureID(id, blinds); err != nil {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, apierrors.InternalServerError(err.Error()))
+			return
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, apierrors.InternalServerError(err.Error()))
+		return
+	}
+
+	result, err := s.store.Structures().FindByID(id)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			ctx.AbortWithStatusJSON(http.StatusNotFound, apierrors.NotFound("Structure not found"))
+			return
+		}
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, apierrors.InternalServerError(err.Error()))
+		return
+	}
+
+	ctx.JSON(http.StatusOK, result)
 }
 
 // deleteStructure handles the deletion of an existing structure.
@@ -209,7 +269,6 @@ func (s *structuresController) updateStructure(ctx *gin.Context) {
 // @Failure 400 {object} ErrorResponse
 // @Failure 401 {object} ErrorResponse
 // @Failure 403 {object} ErrorResponse
-// @Failure 404 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse
 // @Router /structures/{id} [delete]
 func (s *structuresController) deleteStructure(ctx *gin.Context) {
@@ -219,17 +278,9 @@ func (s *structuresController) deleteStructure(ctx *gin.Context) {
 		return
 	}
 
-	svc := services.NewStructureService(s.db)
-	err = svc.DeleteStructure(id)
-	if err != nil {
-		if apiErr, ok := err.(apierrors.APIErrorResponse); ok {
-			ctx.AbortWithStatusJSON(apiErr.Code, apiErr)
-			return
-		}
-		ctx.AbortWithStatusJSON(
-			http.StatusInternalServerError,
-			apierrors.InternalServerError(err.Error()),
-		)
+	err = s.store.Structures().Delete(id)
+	if err != nil && !errors.Is(err, store.ErrNotFound) {
+		ctx.AbortWithStatusJSON(http.StatusInternalServerError, apierrors.InternalServerError(err.Error()))
 		return
 	}
 

--- a/server/internal/controller/structures_test.go
+++ b/server/internal/controller/structures_test.go
@@ -752,13 +752,12 @@ func TestDeleteStructure(t *testing.T) {
 			expectedErrorMsg: "Structure ID 'invalid-id' is not a valid integer",
 		},
 		{
-			name:             "non-existent structure",
-			userRole:         authorization.ROLE_TOURNAMENT_DIRECTOR.ToString(),
-			structureID:      "999",
-			seedStructures:   false,
-			expectedStatus:   http.StatusNotFound,
-			expectError:      true,
-			expectedErrorMsg: "Structure not found",
+			name:           "non-existent structure",
+			userRole:       authorization.ROLE_TOURNAMENT_DIRECTOR.ToString(),
+			structureID:    "999",
+			seedStructures: false,
+			expectedStatus: http.StatusNoContent,
+			expectError:    false,
 		},
 	}
 

--- a/server/internal/models/event.go
+++ b/server/internal/models/event.go
@@ -21,8 +21,8 @@ type Event struct {
 	Semester         *Semester     `json:"semester,omitempty"`
 	StartDate        time.Time     `json:"startDate"           gorm:"not null;default:CURRENT_TIMESTAMP"`
 	State            uint8         `json:"state"               gorm:"default:0"`
-	StructureID      int32         `json:"structureId"         gorm:"type:integer;not null;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
-	Structure        *Structure    `json:"structure,omitempty"`
+	StructureID      int32         `json:"structureId"         gorm:"type:integer;not null"`
+	Structure        *Structure    `json:"structure,omitempty" gorm:"constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Rebuys           uint8         `json:"rebuys"              gorm:"not null;default:0"`
 	PointsMultiplier float32       `json:"pointsMultiplier"    gorm:"not null;default:1"`
 	Entries          []Participant `json:"entries,omitempty"   gorm:"foreignKey:EventID"`

--- a/server/internal/models/structures.go
+++ b/server/internal/models/structures.go
@@ -5,7 +5,7 @@ import "gorm.io/gorm"
 type Structure struct {
 	ID     int32   `json:"id" gorm:"type:integer;primaryKey;autoIncrement"`
 	Name   string  `json:"name" gorm:"not null"`
-	Blinds []Blind `json:"blinds" gorm:"foreignKey:StructureId"`
+	Blinds []Blind `json:"blinds" gorm:"foreignKey:StructureId;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 } //@name Structure
 
 func (Structure) TableName() string {
@@ -41,7 +41,7 @@ type Blind struct {
 	Ante        int32 `json:"ante" gorm:"not null"`
 	Time        int8  `json:"time" gorm:"not null"`
 	Index       int8  `json:"-" gorm:"not null"`
-	StructureId int32 `json:"-" gorm:"type:integer;not null;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	StructureId int32 `json:"-" gorm:"type:integer;not null"`
 }//@name Blind
 
 type BlindJSON struct {

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -156,7 +156,7 @@ func (s *apiServer) SetupV2Routes() {
 		controller.NewMembersController(s.db, store),
 		controller.NewMembershipsController(s.db),
 		controller.NewRankingsController(s.db),
-		controller.NewStructuresController(s.db),
+		controller.NewStructuresController(s.db, store),
 		controller.NewLoginsController(s.db),
 	}
 

--- a/server/internal/store/inmemory/member.go
+++ b/server/internal/store/inmemory/member.go
@@ -16,10 +16,28 @@ type inMemoryMemberRepository struct {
 
 var _ store.MemberRepository = (*inMemoryMemberRepository)(nil)
 
-func NewMemberRepository() store.MemberRepository {
+func newMemberRepository() *inMemoryMemberRepository {
 	return &inMemoryMemberRepository{
 		members: make(map[uint64]*models.User),
 	}
+}
+
+func NewMemberRepository() store.MemberRepository {
+	return newMemberRepository()
+}
+
+func (r *inMemoryMemberRepository) clone() *inMemoryMemberRepository {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	c := &inMemoryMemberRepository{
+		members: make(map[uint64]*models.User, len(r.members)),
+	}
+	for id, u := range r.members {
+		uc := *u
+		c.members[id] = &uc
+	}
+	return c
 }
 
 func (r *inMemoryMemberRepository) Create(member *models.User) error {
@@ -36,23 +54,23 @@ func (r *inMemoryMemberRepository) Create(member *models.User) error {
 	return nil
 }
 
-func (r *inMemoryMemberRepository) FindByID(id uint64) (*models.User, error) {
+func (r *inMemoryMemberRepository) FindByID(id uint64) (models.User, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	member, exists := r.members[id]
 	if !exists {
-		return nil, store.ErrNotFound
+		return models.User{}, store.ErrNotFound
 	}
 
-	return member, nil
+	return *member, nil
 }
 
-func (r *inMemoryMemberRepository) List(filter *models.ListUsersFilter, pagination *models.Pagination) ([]*models.User, int64, error) {
+func (r *inMemoryMemberRepository) List(filter *models.ListUsersFilter, pagination *models.Pagination) ([]models.User, int64, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	var members []*models.User
+	var members []models.User
 	for _, member := range r.members {
 		if filter.ID != nil && member.ID != *filter.ID {
 			continue
@@ -69,7 +87,7 @@ func (r *inMemoryMemberRepository) List(filter *models.ListUsersFilter, paginati
 		if filter.Faculty != nil && member.Faculty != *filter.Faculty {
 			continue
 		}
-		members = append(members, member)
+		members = append(members, *member)
 	}
 
 	sort.Slice(members, func(i, j int) bool {
@@ -84,7 +102,7 @@ func (r *inMemoryMemberRepository) List(filter *models.ListUsersFilter, paginati
 	}
 
 	if offset >= len(members) {
-		return []*models.User{}, total, nil
+		return []models.User{}, total, nil
 	}
 
 	members = members[offset:]

--- a/server/internal/store/inmemory/semester.go
+++ b/server/internal/store/inmemory/semester.go
@@ -16,10 +16,28 @@ type inMemorySemesterRepository struct {
 
 var _ store.SemesterRepository = (*inMemorySemesterRepository)(nil)
 
-func NewSemesterRepository() store.SemesterRepository {
+func newSemesterRepository() *inMemorySemesterRepository {
 	return &inMemorySemesterRepository{
 		semesters: make(map[uuid.UUID]*models.Semester),
 	}
+}
+
+func NewSemesterRepository() store.SemesterRepository {
+	return newSemesterRepository()
+}
+
+func (r *inMemorySemesterRepository) clone() *inMemorySemesterRepository {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	c := &inMemorySemesterRepository{
+		semesters: make(map[uuid.UUID]*models.Semester, len(r.semesters)),
+	}
+	for id, s := range r.semesters {
+		sc := *s
+		c.semesters[id] = &sc
+	}
+	return c
 }
 
 func (r *inMemorySemesterRepository) Create(semester *models.Semester) error {
@@ -33,22 +51,22 @@ func (r *inMemorySemesterRepository) Create(semester *models.Semester) error {
 	return nil
 }
 
-func (r *inMemorySemesterRepository) FindByID(id uuid.UUID) (*models.Semester, error) {
+func (r *inMemorySemesterRepository) FindByID(id uuid.UUID) (models.Semester, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	semester, exists := r.semesters[id]
 	if !exists {
-		return nil, store.ErrNotFound
+		return models.Semester{}, store.ErrNotFound
 	}
-	return semester, nil
+	return *semester, nil
 }
 
-func (r *inMemorySemesterRepository) List(pagination *models.Pagination) ([]*models.Semester, int64, error) {
+func (r *inMemorySemesterRepository) List(pagination *models.Pagination) ([]models.Semester, int64, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	var semesters []*models.Semester
+	var semesters []models.Semester
 	for _, semester := range r.semesters {
-		semesters = append(semesters, semester)
+		semesters = append(semesters, *semester)
 	}
 	sort.Slice(semesters, func(i, j int) bool {
 		return semesters[i].StartDate.After(semesters[j].StartDate)
@@ -60,7 +78,7 @@ func (r *inMemorySemesterRepository) List(pagination *models.Pagination) ([]*mod
 		offset = *pagination.Offset
 	}
 	if offset >= len(semesters) {
-		return []*models.Semester{}, total, nil
+		return []models.Semester{}, total, nil
 	}
 	semesters = semesters[offset:]
 

--- a/server/internal/store/inmemory/store.go
+++ b/server/internal/store/inmemory/store.go
@@ -2,73 +2,95 @@ package inmemory
 
 import (
 	"api/internal/store"
+	"sync"
 )
 
 type InMemoryStore struct {
-	semesters store.SemesterRepository
-	memberships store.MembershipRepository
-	members store.MemberRepository
-	events store.EventRepository
-	entries store.EntryRepository
-	rankings store.RankingRepository
-	structures store.StructureRepository
-	logins store.LoginRepository
-	sessions store.SessionRepository
+	mu         sync.RWMutex
+	semesters  *inMemorySemesterRepository
+	members    *inMemoryMemberRepository
+	structures *inMemoryStructureRepository
+	parent     *InMemoryStore
 }
 
 var _ store.Store = (*InMemoryStore)(nil)
 
 func NewStore() store.Store {
 	return &InMemoryStore{
-		semesters: NewSemesterRepository(),
-		members: NewMemberRepository(),
+		semesters:  newSemesterRepository(),
+		members:    newMemberRepository(),
+		structures: newStructureRepository(),
 	}
 }
 
 func (s *InMemoryStore) Semesters() store.SemesterRepository {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.semesters
 }
 
-func (s *InMemoryStore) Memberships() store.MembershipRepository {
-	return s.memberships
-}
-
 func (s *InMemoryStore) Members() store.MemberRepository {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.members
 }
 
-func (s *InMemoryStore) Events() store.EventRepository {
-	return s.events
-}
-
-func (s *InMemoryStore) Entries() store.EntryRepository {
-	return s.entries
-}
-
-func (s *InMemoryStore) Rankings() store.RankingRepository {
-	return s.rankings
-}
-
 func (s *InMemoryStore) Structures() store.StructureRepository {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.structures
 }
 
-func (s *InMemoryStore) Logins() store.LoginRepository {
-	return s.logins
-}
+func (s *InMemoryStore) Memberships() store.MembershipRepository { return nil }
+func (s *InMemoryStore) Events() store.EventRepository           { return nil }
+func (s *InMemoryStore) Entries() store.EntryRepository          { return nil }
+func (s *InMemoryStore) Rankings() store.RankingRepository       { return nil }
+func (s *InMemoryStore) Logins() store.LoginRepository           { return nil }
+func (s *InMemoryStore) Sessions() store.SessionRepository       { return nil }
 
-func (s *InMemoryStore) Sessions() store.SessionRepository {
-	return s.sessions
-}
-
+// BeginTx snapshots all active repos into a new InMemoryStore. The returned
+// store operates on its own copy of the data, leaving the parent untouched
+// until Commit is called.
 func (s *InMemoryStore) BeginTx() (store.Store, error) {
-	return s, nil
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	tx := &InMemoryStore{parent: s}
+	if s.structures != nil {
+		tx.structures = s.structures.clone()
+	}
+	if s.members != nil {
+		tx.members = s.members.clone()
+	}
+	if s.semesters != nil {
+		tx.semesters = s.semesters.clone()
+	}
+	return tx, nil
 }
 
+// Commit atomically replaces the parent's repos with the transaction's repos.
 func (s *InMemoryStore) Commit() error {
+	if s.parent == nil {
+		return nil
+	}
+	s.parent.mu.Lock()
+	defer s.parent.mu.Unlock()
+	if s.structures != nil {
+		s.parent.structures = s.structures
+	}
+	if s.members != nil {
+		s.parent.members = s.members
+	}
+	if s.semesters != nil {
+		s.parent.semesters = s.semesters
+	}
 	return nil
 }
 
+// Rollback is a no-op: the snapshot approach means the parent's repos are
+// never modified until Commit, so uncommitted changes are simply discarded
+// when the transaction store is garbage collected. Calling Rollback after
+// Commit is also safe.
 func (s *InMemoryStore) Rollback() error {
 	return nil
 }

--- a/server/internal/store/inmemory/structure.go
+++ b/server/internal/store/inmemory/structure.go
@@ -1,0 +1,148 @@
+package inmemory
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+type inMemoryStructureRepository struct {
+  mu         sync.RWMutex
+  structures map[int32]*models.Structure
+  nextID     int32
+}
+
+var _ store.StructureRepository = (*inMemoryStructureRepository)(nil)
+
+func newStructureRepository() *inMemoryStructureRepository {
+  return &inMemoryStructureRepository{
+    structures: make(map[int32]*models.Structure),
+  }
+}
+
+func NewStructureRepository() store.StructureRepository {
+  return newStructureRepository()
+}
+
+func (r *inMemoryStructureRepository) clone() *inMemoryStructureRepository {
+  r.mu.RLock()
+  defer r.mu.RUnlock()
+
+  c := &inMemoryStructureRepository{
+    structures: make(map[int32]*models.Structure, len(r.structures)),
+    nextID:     r.nextID,
+  }
+  for id, s := range r.structures {
+    sc := *s
+    if s.Blinds != nil {
+      sc.Blinds = make([]models.Blind, len(s.Blinds))
+      copy(sc.Blinds, s.Blinds)
+    }
+    c.structures[id] = &sc
+  }
+  return c
+}
+
+func (r *inMemoryStructureRepository) Create(structure *models.Structure) error {
+  r.mu.Lock()
+  defer r.mu.Unlock()
+
+  if structure.ID == 0 {
+    r.nextID++
+    structure.ID = r.nextID
+  } else if _, exists := r.structures[structure.ID]; exists {
+    return fmt.Errorf("structure with ID %d already exists", structure.ID)
+  }
+
+  copy := *structure
+  r.structures[structure.ID] = &copy
+
+  return nil
+}
+
+func (r *inMemoryStructureRepository) FindByID(id int32) (models.Structure, error) {
+  r.mu.RLock()
+  defer r.mu.RUnlock()
+
+  structure, exists := r.structures[id]
+  if !exists {
+    return models.Structure{}, store.ErrNotFound
+}
+
+  return *structure, nil
+}
+
+func (r *inMemoryStructureRepository) List(pagination *models.Pagination) ([]models.Structure, int64, error) {
+  r.mu.RLock()
+  defer r.mu.RUnlock()
+
+  var structures []models.Structure
+  for _, structure := range r.structures {
+    structures = append(structures, *structure)
+  }
+
+  sort.Slice(structures, func(i, j int) bool {
+    return structures[i].ID > structures[j].ID
+  })
+  
+  total := int64(len(structures))
+  
+  offset := 0
+  if pagination.Offset != nil && *pagination.Offset > 0 {
+    offset = *pagination.Offset
+  }
+
+  if offset >= len(structures) {
+    return []models.Structure{}, total, nil
+  }
+
+  structures = structures[offset:]
+
+  if pagination.Limit != nil && *pagination.Limit > 0 && *pagination.Limit < len(structures) {
+    structures = structures[:*pagination.Limit]
+  }
+
+  return structures, total, nil
+}
+
+func (r *inMemoryStructureRepository) Update(structure *models.Structure) error {
+  r.mu.Lock()
+  defer r.mu.Unlock()
+
+  existing, exists := r.structures[structure.ID]
+  if !exists {
+    return store.ErrNotFound
+  }
+
+  existing.Name = structure.Name
+
+  return nil
+}
+
+func (r *inMemoryStructureRepository) ReplaceBlindsByStructureID(structureID int32, blinds []models.Blind) error {
+  r.mu.Lock()
+  defer r.mu.Unlock()
+
+  structure, exists := r.structures[structureID]
+  if !exists {
+    return store.ErrNotFound
+  }
+
+  structure.Blinds = blinds
+  return nil
+}
+
+func (r *inMemoryStructureRepository) Delete(id int32) error {
+  r.mu.Lock()
+  defer r.mu.Unlock()
+
+  if _, exists := r.structures[id]; !exists {
+    return store.ErrNotFound
+  }
+
+  delete(r.structures, id)
+  
+  return nil
+}

--- a/server/internal/store/member.go
+++ b/server/internal/store/member.go
@@ -8,10 +8,10 @@ type MemberRepository interface {
 	Create(member *models.User) error
 
 	// FindByID finds a member by their ID. It returns the member or error encountered.
-	FindByID(id uint64) (*models.User, error)
+	FindByID(id uint64) (models.User, error)
 
 	// List returns a list of all members in the data store matching the given filter. It returns the list of members or error encountered.
-	List(filter *models.ListUsersFilter, pagination *models.Pagination) ([]*models.User, int64, error)
+	List(filter *models.ListUsersFilter, pagination *models.Pagination) ([]models.User, int64, error)
 
 	// Update updates an existing member in the data store. It returns error encountered.
 	Update(member *models.User) error

--- a/server/internal/store/postgres/member.go
+++ b/server/internal/store/postgres/member.go
@@ -22,21 +22,21 @@ func (r *postgresMemberRepository) Create(member *models.User) error {
 	return r.db.Create(member).Error
 }
 
-func (r *postgresMemberRepository) FindByID(id uint64) (*models.User, error) {
+func (r *postgresMemberRepository) FindByID(id uint64) (models.User, error) {
 	var member models.User
 	if err := r.db.First(&member, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, store.ErrNotFound
+			return models.User{}, store.ErrNotFound
 		}
 
-		return nil, err
+		return models.User{}, err
 	}
 
-	return &member, nil
+	return member, nil
 }
 
-func (r *postgresMemberRepository) List(filter *models.ListUsersFilter, pagination *models.Pagination) ([]*models.User, int64, error) {
-	var members []*models.User
+func (r *postgresMemberRepository) List(filter *models.ListUsersFilter, pagination *models.Pagination) ([]models.User, int64, error) {
+	var members []models.User
 	var total int64
 
 	base := r.db.Model(&models.User{})

--- a/server/internal/store/postgres/semester.go
+++ b/server/internal/store/postgres/semester.go
@@ -23,19 +23,19 @@ func (r *postgresSemesterRepository) Create(semester *models.Semester) error {
 	return r.db.Create(semester).Error
 }
 
-func (r *postgresSemesterRepository) FindByID(id uuid.UUID) (*models.Semester, error) {
+func (r *postgresSemesterRepository) FindByID(id uuid.UUID) (models.Semester, error) {
 	var semester models.Semester
 	if err := r.db.First(&semester, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, store.ErrNotFound
+			return models.Semester{}, store.ErrNotFound
 		}
-		return nil, err
+		return models.Semester{}, err
 	}
-	return &semester, nil
+	return semester, nil
 }
 
-func (r *postgresSemesterRepository) List(pagination *models.Pagination) ([]*models.Semester, int64, error) {
-	var semesters []*models.Semester
+func (r *postgresSemesterRepository) List(pagination *models.Pagination) ([]models.Semester, int64, error) {
+	var semesters []models.Semester
 	var total int64
 
 	base := r.db.Model(&models.Semester{})

--- a/server/internal/store/postgres/store.go
+++ b/server/internal/store/postgres/store.go
@@ -46,6 +46,7 @@ func NewStore(db *gorm.DB) store.Store {
 		db:        db,
 		semesters: NewSemesterRepository(db),
 		members: 	NewMemberRepository(db),
+    structures: NewStructureRepository(db),
 	}
 }
 
@@ -95,6 +96,7 @@ func (s *PostgresStore) BeginTx() (store.Store, error) {
 		db:        tx,
 		semesters: NewSemesterRepository(tx),
 		members:   NewMemberRepository(tx),
+    structures: NewStructureRepository(tx),
 	}, nil
 }
 

--- a/server/internal/store/postgres/structure.go
+++ b/server/internal/store/postgres/structure.go
@@ -1,0 +1,96 @@
+package postgres
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"errors"
+
+	"gorm.io/gorm"
+)
+
+type postgresStructureRepository struct {
+	db *gorm.DB
+}
+
+var _ store.StructureRepository = (*postgresStructureRepository)(nil)
+
+func NewStructureRepository(db *gorm.DB) store.StructureRepository {
+	return &postgresStructureRepository{db: db}
+}
+
+func (r *postgresStructureRepository) Create(structure *models.Structure) error {
+	return r.db.Create(structure).Error
+}
+
+func (r *postgresStructureRepository) FindByID(id int32) (models.Structure, error) {
+	structure := models.Structure{
+		ID: id,
+	}
+
+	res := structure.Preload(r.db, models.StructurePreloadOptions{Blinds: true}).First(&structure)	
+	if err := res.Error; err != nil {	
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Structure{}, store.ErrNotFound
+		}
+
+		return models.Structure{}, err
+	}
+
+	return structure, nil
+}
+
+func (r *postgresStructureRepository) List(pagination *models.Pagination) ([]models.Structure, int64, error) {
+	var structures []models.Structure
+	var total int64
+
+	base := r.db.Model(&models.Structure{})
+
+	if err := base.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	query := base.Order("id DESC")
+	query = pagination.Apply(query)
+
+	if err := query.Find(&structures).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return structures, total, nil
+}
+
+func (r *postgresStructureRepository) Update(structure *models.Structure) error {
+	return r.db.Model(structure).Select("name").Updates(structure).Error
+}
+
+func (r *postgresStructureRepository) ReplaceBlindsByStructureID(structureID int32, blinds []models.Blind) error {
+	if err := r.db.Where("structure_id = ?", structureID).Delete(&models.Blind{}).Error; err != nil {
+		return err
+	}
+	if len(blinds) > 0 {
+		return r.db.Create(&blinds).Error
+	}
+	// FK constraint only catches non-existent structure when blinds are inserted.
+	// With an empty slice, verify the structure exists explicitly.
+	var count int64
+	if err := r.db.Model(&models.Structure{}).Where("id = ?", structureID).Count(&count).Error; err != nil {
+		return err
+	}
+	if count == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
+func (r *postgresStructureRepository) Delete(id int32) error {
+	result := r.db.Delete(&models.Structure{}, id)
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	if result.RowsAffected == 0 {
+		return store.ErrNotFound
+	}
+
+	return nil
+}

--- a/server/internal/store/semester.go
+++ b/server/internal/store/semester.go
@@ -9,7 +9,7 @@ import (
 // SemesterRepository is the interface for accessing the semesters in the data store. It provides methods for creating, reading, updating, and deleting semesters.
 type SemesterRepository interface {
 	Create(semester *models.Semester) error
-	FindByID(id uuid.UUID) (*models.Semester, error)
-	List(pagination *models.Pagination) ([]*models.Semester, int64, error)
+	FindByID(id uuid.UUID) (models.Semester, error)
+	List(pagination *models.Pagination) ([]models.Semester, int64, error)
 	Update(semester *models.Semester) error
 }

--- a/server/internal/store/structure.go
+++ b/server/internal/store/structure.go
@@ -1,4 +1,24 @@
 package store
 
+import "api/internal/models"
+
 // StructureRepistory is the interface for accessing the structures in the data store. It provides methods for creating, reading, updating, and deleting structures.
-type StructureRepository interface {}
+type StructureRepository interface {
+	// Create creates a new structure in the data store.
+	Create(structure *models.Structure) error
+
+	// FindByID retrieves a structure from the data store by its ID.
+	FindByID(id int32) (models.Structure, error)
+
+	// List retrieves all structures from the data store.
+	List(pagination *models.Pagination) ([]models.Structure, int64, error)
+
+	// Update updates an existing structure in the data store.
+	Update(structure *models.Structure) error
+
+	// ReplaceBlindsByStructureID replaces all blinds for a structure with the given blinds.
+	ReplaceBlindsByStructureID(structureID int32, blinds []models.Blind) error
+
+	// Delete deletes a structure from the data store by its ID.
+	Delete(id int32) error
+}


### PR DESCRIPTION
## Description
Implements `StructureRepository` as part of the ongoing store/repository pattern migration (UWPSC-84). Migrates the structures controller from direct service/GORM calls to the store interface, and fixes several bugs found during review.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] E2E tests pass
- [x] Manual testing completed

## Database Changes
- [ ] No database changes
- [x] Migration included and tested
- [x] Atlas migration generated

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added for new functionality
- [ ] Documentation updated

---

**Key changes:**

- `store.StructureRepository` interface with `Create`, `FindByID`, `List`, `Update`, `ReplaceBlindsByStructureID`, and `Delete`
- Postgres and in-memory implementations, including `ReplaceBlindsByStructureID` which handles atomic blind replacement within a transaction
- Structures controller fully migrated off `StructureService` — all five handlers (`list`, `create`, `get`, `update`, `delete`) now use the store directly
- `updateStructure` uses `BeginTx`/`Commit` for atomic name + blinds replacement
- `deleteStructure` is now idempotent (returns 204 for non-existent structures)
- Two Atlas migrations: fix `blinds.structure_id` FK to `ON DELETE CASCADE` (constraint tag was on the wrong field in the GORM model), and the same fix for `events.structure_id`
- `MemberRepository` and `SemesterRepository` return value types instead of pointers, consistent with other repos
- `InMemoryStore.BeginTx()` now takes a real snapshot (deep-copies each repo's map), with `Commit()` atomically swapping the repos back into the parent and `Rollback()` being a true no-op — previously `BeginTx` returned `self`, making both a no-op and leaving partial writes unrollable