### PR TITLE
Implement membership repository

### DIFF
--- a/server/internal/store/inmemory/membership.go
+++ b/server/internal/store/inmemory/membership.go
@@ -1,0 +1,156 @@
+package inmemory
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type inMemoryMembershipRepository struct {
+	mu          sync.RWMutex
+	memberships map[uuid.UUID]*models.Membership
+}
+
+var _ store.MembershipRepository = (*inMemoryMembershipRepository)(nil)
+
+func newMembershipRepository() *inMemoryMembershipRepository {
+	return &inMemoryMembershipRepository{
+		memberships: make(map[uuid.UUID]*models.Membership),
+	}
+}
+
+func NewMembershipRepository() store.MembershipRepository {
+	return newMembershipRepository()
+}
+
+func (r *inMemoryMembershipRepository) clone() *inMemoryMembershipRepository {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	c := &inMemoryMembershipRepository{
+		memberships: make(map[uuid.UUID]*models.Membership, len(r.memberships)),
+	}
+	for id, m := range r.memberships {
+		mc := *m
+		c.memberships[id] = &mc
+	}
+	return c
+}
+
+func (r *inMemoryMembershipRepository) Create(membership *models.Membership) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if membership.ID == uuid.Nil {
+		membership.ID = uuid.New()
+	} else if _, exists := r.memberships[membership.ID]; exists {
+		return fmt.Errorf("membership with ID %s already exists", membership.ID)
+	}
+
+	copy := *membership
+	r.memberships[membership.ID] = &copy
+
+	return nil
+}
+
+func (r *inMemoryMembershipRepository) FindByID(id uuid.UUID) (models.Membership, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	membership, exists := r.memberships[id]
+	if !exists {
+		return models.Membership{}, store.ErrNotFound
+	}
+
+	return *membership, nil
+}
+
+func (r *inMemoryMembershipRepository) FindByIDAndSemesterID(id uuid.UUID, semesterID uuid.UUID) (models.Membership, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	membership, exists := r.memberships[id]
+	if !exists || membership.SemesterID != semesterID {
+		return models.Membership{}, store.ErrNotFound
+	}
+
+	return *membership, nil
+}
+
+func (r *inMemoryMembershipRepository) List(filter *models.ListMembershipsFilter) ([]models.Membership, int64, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var memberships []models.Membership
+	for _, membership := range r.memberships {
+		if filter.SemesterID != nil && membership.SemesterID != *filter.SemesterID {
+			continue
+		}
+		if filter.UserID != nil && membership.UserID != *filter.UserID {
+			continue
+		}
+		if filter.Paid != nil && membership.Paid != *filter.Paid {
+			continue
+		}
+		if filter.Discounted != nil && membership.Discounted != *filter.Discounted {
+			continue
+		}
+		memberships = append(memberships, *membership)
+	}
+
+	sort.Slice(memberships, func(i, j int) bool {
+		return memberships[i].UserID < memberships[j].UserID
+	})
+
+	total := int64(len(memberships))
+
+	offset := 0
+	if filter.Pagination.Offset != nil && *filter.Pagination.Offset > 0 {
+		offset = *filter.Pagination.Offset
+	}
+
+	if offset >= len(memberships) {
+		return []models.Membership{}, total, nil
+	}
+
+	memberships = memberships[offset:]
+
+	if filter.Pagination.Limit != nil && *filter.Pagination.Limit > 0 && *filter.Pagination.Limit < len(memberships) {
+		memberships = memberships[:*filter.Pagination.Limit]
+	}
+
+	return memberships, total, nil
+}
+
+func (r *inMemoryMembershipRepository) Update(membership *models.Membership) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	existing, exists := r.memberships[membership.ID]
+	if !exists {
+		return store.ErrNotFound
+	}
+
+	existing.Paid = membership.Paid
+	existing.Discounted = membership.Discounted
+
+	return nil
+}
+
+func (r *inMemoryMembershipRepository) Delete(id uuid.UUID, semesterID uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	membership, exists := r.memberships[id]
+	if !exists || membership.SemesterID != semesterID {
+		return store.ErrNotFound
+	}
+
+	delete(r.memberships, id)
+
+	return nil
+}

--- a/server/internal/store/inmemory/membership.go
+++ b/server/internal/store/inmemory/membership.go
@@ -51,6 +51,12 @@ func (r *inMemoryMembershipRepository) Create(membership *models.Membership) err
 		return fmt.Errorf("membership with ID %s already exists", membership.ID)
 	}
 
+	for _, m := range r.memberships {
+		if m.UserID == membership.UserID && m.SemesterID == membership.SemesterID {
+			return fmt.Errorf("membership for user %d in semester %s already exists", membership.UserID, membership.SemesterID)
+		}
+	}
+
 	copy := *membership
 	r.memberships[membership.ID] = &copy
 

--- a/server/internal/store/inmemory/membership_test.go
+++ b/server/internal/store/inmemory/membership_test.go
@@ -42,6 +42,18 @@ func TestMembershipRepository_Create_DuplicateID(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestMembershipRepository_Create_DuplicateUserSemester(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	semesterID := uuid.New()
+	require.NoError(t, repo.Create(&models.Membership{UserID: 1, SemesterID: semesterID}))
+
+	err := repo.Create(&models.Membership{UserID: 1, SemesterID: semesterID})
+	require.Error(t, err)
+}
+
 func TestMembershipRepository_FindByID_NotFound(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/store/inmemory/membership_test.go
+++ b/server/internal/store/inmemory/membership_test.go
@@ -1,0 +1,190 @@
+package inmemory
+
+import (
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMembershipRepository_CreateAndFindByID(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	membership := &models.Membership{
+		UserID:     1,
+		SemesterID: uuid.New(),
+		Paid:       true,
+		Discounted: false,
+	}
+
+	require.NoError(t, repo.Create(membership))
+	require.NotEqual(t, uuid.Nil, membership.ID)
+
+	found, err := repo.FindByID(membership.ID)
+	require.NoError(t, err)
+	require.Equal(t, *membership, found)
+}
+
+func TestMembershipRepository_Create_DuplicateID(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	id := uuid.New()
+	require.NoError(t, repo.Create(&models.Membership{ID: id, UserID: 1, SemesterID: uuid.New()}))
+
+	err := repo.Create(&models.Membership{ID: id, UserID: 2, SemesterID: uuid.New()})
+	require.Error(t, err)
+}
+
+func TestMembershipRepository_FindByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	_, err := repo.FindByID(uuid.New())
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMembershipRepository_FindByIDAndSemesterID(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	semesterA := uuid.New()
+	semesterB := uuid.New()
+
+	membership := &models.Membership{UserID: 1, SemesterID: semesterA}
+	require.NoError(t, repo.Create(membership))
+
+	found, err := repo.FindByIDAndSemesterID(membership.ID, semesterA)
+	require.NoError(t, err)
+	require.Equal(t, membership.ID, found.ID)
+
+	_, err = repo.FindByIDAndSemesterID(membership.ID, semesterB)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMembershipRepository_List(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	semesterA := uuid.New()
+	semesterB := uuid.New()
+
+	m1 := &models.Membership{UserID: 1, SemesterID: semesterA, Paid: true}
+	m2 := &models.Membership{UserID: 2, SemesterID: semesterA, Paid: false}
+	m3 := &models.Membership{UserID: 3, SemesterID: semesterB, Paid: true}
+	require.NoError(t, repo.Create(m1))
+	require.NoError(t, repo.Create(m2))
+	require.NoError(t, repo.Create(m3))
+
+	results, total, err := repo.List(&models.ListMembershipsFilter{SemesterID: &semesterA})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total)
+	require.Len(t, results, 2)
+	require.Equal(t, uint64(1), results[0].UserID)
+	require.Equal(t, uint64(2), results[1].UserID)
+
+	paidTrue := true
+	results, total, err = repo.List(&models.ListMembershipsFilter{SemesterID: &semesterA, Paid: &paidTrue})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Equal(t, m1.ID, results[0].ID)
+
+	limit := 1
+	offset := 1
+	results, total, err = repo.List(&models.ListMembershipsFilter{
+		SemesterID: &semesterA,
+		Pagination: models.Pagination{Limit: &limit, Offset: &offset},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total)
+	require.Len(t, results, 1)
+	require.Equal(t, uint64(2), results[0].UserID)
+}
+
+func TestMembershipRepository_Update(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	membership := &models.Membership{UserID: 1, SemesterID: uuid.New(), Paid: true, Discounted: true}
+	require.NoError(t, repo.Create(membership))
+
+	update := &models.Membership{ID: membership.ID, Paid: false, Discounted: false}
+	require.NoError(t, repo.Update(update))
+
+	found, err := repo.FindByID(membership.ID)
+	require.NoError(t, err)
+	require.False(t, found.Paid)
+	require.False(t, found.Discounted)
+}
+
+func TestMembershipRepository_Update_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	err := repo.Update(&models.Membership{ID: uuid.New()})
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMembershipRepository_Delete(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	semesterA := uuid.New()
+	semesterB := uuid.New()
+
+	membership := &models.Membership{UserID: 1, SemesterID: semesterA}
+	require.NoError(t, repo.Create(membership))
+
+	err := repo.Delete(membership.ID, semesterB)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.NoError(t, repo.Delete(membership.ID, semesterA))
+
+	_, err = repo.FindByID(membership.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMembershipRepository_Clone_Isolation(t *testing.T) {
+	t.Parallel()
+
+	repo := newMembershipRepository()
+
+	membership := &models.Membership{UserID: 1, SemesterID: uuid.New(), Paid: false}
+	require.NoError(t, repo.Create(membership))
+
+	clone := repo.clone()
+
+	// Mutating the clone must not affect the original.
+	require.NoError(t, clone.Update(&models.Membership{ID: membership.ID, Paid: true}))
+
+	original, err := repo.FindByID(membership.ID)
+	require.NoError(t, err)
+	require.False(t, original.Paid)
+
+	cloned, err := clone.FindByID(membership.ID)
+	require.NoError(t, err)
+	require.True(t, cloned.Paid)
+
+	// Creating a new membership on the original must not appear in the clone.
+	require.NoError(t, repo.Create(&models.Membership{UserID: 2, SemesterID: uuid.New()}))
+
+	_, cloneTotal, err := clone.List(&models.ListMembershipsFilter{})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, cloneTotal)
+
+	_, originalTotal, err := repo.List(&models.ListMembershipsFilter{})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, originalTotal)
+}

--- a/server/internal/store/inmemory/store.go
+++ b/server/internal/store/inmemory/store.go
@@ -6,20 +6,22 @@ import (
 )
 
 type InMemoryStore struct {
-	mu         sync.RWMutex
-	semesters  *inMemorySemesterRepository
-	members    *inMemoryMemberRepository
-	structures *inMemoryStructureRepository
-	parent     *InMemoryStore
+	mu          sync.RWMutex
+	semesters   *inMemorySemesterRepository
+	members     *inMemoryMemberRepository
+	memberships *inMemoryMembershipRepository
+	structures  *inMemoryStructureRepository
+	parent      *InMemoryStore
 }
 
 var _ store.Store = (*InMemoryStore)(nil)
 
 func NewStore() store.Store {
 	return &InMemoryStore{
-		semesters:  newSemesterRepository(),
-		members:    newMemberRepository(),
-		structures: newStructureRepository(),
+		semesters:   newSemesterRepository(),
+		members:     newMemberRepository(),
+		memberships: newMembershipRepository(),
+		structures:  newStructureRepository(),
 	}
 }
 
@@ -41,12 +43,17 @@ func (s *InMemoryStore) Structures() store.StructureRepository {
 	return s.structures
 }
 
-func (s *InMemoryStore) Memberships() store.MembershipRepository { return nil }
-func (s *InMemoryStore) Events() store.EventRepository           { return nil }
-func (s *InMemoryStore) Entries() store.EntryRepository          { return nil }
-func (s *InMemoryStore) Rankings() store.RankingRepository       { return nil }
-func (s *InMemoryStore) Logins() store.LoginRepository           { return nil }
-func (s *InMemoryStore) Sessions() store.SessionRepository       { return nil }
+func (s *InMemoryStore) Memberships() store.MembershipRepository {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.memberships
+}
+
+func (s *InMemoryStore) Events() store.EventRepository     { return nil }
+func (s *InMemoryStore) Entries() store.EntryRepository    { return nil }
+func (s *InMemoryStore) Rankings() store.RankingRepository { return nil }
+func (s *InMemoryStore) Logins() store.LoginRepository     { return nil }
+func (s *InMemoryStore) Sessions() store.SessionRepository { return nil }
 
 // BeginTx snapshots all active repos into a new InMemoryStore. The returned
 // store operates on its own copy of the data, leaving the parent untouched
@@ -61,6 +68,9 @@ func (s *InMemoryStore) BeginTx() (store.Store, error) {
 	}
 	if s.members != nil {
 		tx.members = s.members.clone()
+	}
+	if s.memberships != nil {
+		tx.memberships = s.memberships.clone()
 	}
 	if s.semesters != nil {
 		tx.semesters = s.semesters.clone()
@@ -80,6 +90,9 @@ func (s *InMemoryStore) Commit() error {
 	}
 	if s.members != nil {
 		s.parent.members = s.members
+	}
+	if s.memberships != nil {
+		s.parent.memberships = s.memberships
 	}
 	if s.semesters != nil {
 		s.parent.semesters = s.semesters

--- a/server/internal/store/inmemory/store_test.go
+++ b/server/internal/store/inmemory/store_test.go
@@ -1,0 +1,62 @@
+package inmemory
+
+import (
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Memberships(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	membership := &models.Membership{UserID: 1, SemesterID: uuid.New(), Paid: true}
+	require.NoError(t, s.Memberships().Create(membership))
+
+	found, err := s.Memberships().FindByID(membership.ID)
+	require.NoError(t, err)
+	require.Equal(t, membership.ID, found.ID)
+}
+
+func TestStore_BeginTx_Memberships_Commit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	membership := &models.Membership{UserID: 1, SemesterID: uuid.New(), Paid: true}
+	require.NoError(t, tx.Memberships().Create(membership))
+
+	// The parent store must not see the membership until Commit is called.
+	_, err = s.Memberships().FindByID(membership.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.NoError(t, tx.Commit())
+
+	found, err := s.Memberships().FindByID(membership.ID)
+	require.NoError(t, err)
+	require.Equal(t, membership.ID, found.ID)
+}
+
+func TestStore_BeginTx_Memberships_DiscardedWithoutCommit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	membership := &models.Membership{UserID: 1, SemesterID: uuid.New(), Paid: true}
+	require.NoError(t, tx.Memberships().Create(membership))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Memberships().FindByID(membership.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/membership.go
+++ b/server/internal/store/membership.go
@@ -1,4 +1,32 @@
 package store
 
+import (
+	"api/internal/models"
+
+	"github.com/google/uuid"
+)
+
 // MembershipRepository is the interface for accessing the memberships in the data store. It provides methods for creating, reading, updating, and deleting memberships.
-type MembershipRepository interface {}
+type MembershipRepository interface {
+	// Create creates a new membership in the data store.
+	Create(membership *models.Membership) error
+
+	// FindByID retrieves a membership from the data store by its ID.
+	FindByID(id uuid.UUID) (models.Membership, error)
+
+	// FindByIDAndSemesterID retrieves a membership from the data store by its ID, scoped to a specific semester.
+	FindByIDAndSemesterID(id uuid.UUID, semesterID uuid.UUID) (models.Membership, error)
+
+	// List retrieves memberships from the data store matching the filter's SemesterID, UserID, Paid, and
+	// Discounted fields, ordered by UserID ascending. Filtering on joined member fields (name, email,
+	// faculty, student ID, search) requires a join against the members table and is not performed at
+	// this layer; callers needing that filtering continue to use the service layer for now.
+	List(filter *models.ListMembershipsFilter) ([]models.Membership, int64, error)
+
+	// Update updates an existing membership's Paid and Discounted fields in the data store.
+	Update(membership *models.Membership) error
+
+	// Delete deletes a membership from the data store by its ID, scoped to a specific semester. Returns
+	// ErrNotFound if no matching record exists.
+	Delete(id uuid.UUID, semesterID uuid.UUID) error
+}

--- a/server/internal/store/postgres/membership.go
+++ b/server/internal/store/postgres/membership.go
@@ -1,0 +1,100 @@
+package postgres
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"errors"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type postgresMembershipRepository struct {
+	db *gorm.DB
+}
+
+var _ store.MembershipRepository = (*postgresMembershipRepository)(nil)
+
+func NewMembershipRepository(db *gorm.DB) store.MembershipRepository {
+	return &postgresMembershipRepository{db: db}
+}
+
+func (r *postgresMembershipRepository) Create(membership *models.Membership) error {
+	return r.db.Create(membership).Error
+}
+
+func (r *postgresMembershipRepository) FindByID(id uuid.UUID) (models.Membership, error) {
+	var membership models.Membership
+	if err := r.db.First(&membership, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Membership{}, store.ErrNotFound
+		}
+
+		return models.Membership{}, err
+	}
+
+	return membership, nil
+}
+
+func (r *postgresMembershipRepository) FindByIDAndSemesterID(id uuid.UUID, semesterID uuid.UUID) (models.Membership, error) {
+	var membership models.Membership
+	if err := r.db.First(&membership, "id = ? AND semester_id = ?", id, semesterID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Membership{}, store.ErrNotFound
+		}
+
+		return models.Membership{}, err
+	}
+
+	return membership, nil
+}
+
+func (r *postgresMembershipRepository) List(filter *models.ListMembershipsFilter) ([]models.Membership, int64, error) {
+	var memberships []models.Membership
+	var total int64
+
+	base := r.db.Model(&models.Membership{})
+
+	if filter.SemesterID != nil {
+		base = base.Where("semester_id = ?", *filter.SemesterID)
+	}
+	if filter.UserID != nil {
+		base = base.Where("user_id = ?", *filter.UserID)
+	}
+	if filter.Paid != nil {
+		base = base.Where("paid = ?", *filter.Paid)
+	}
+	if filter.Discounted != nil {
+		base = base.Where("discounted = ?", *filter.Discounted)
+	}
+
+	if err := base.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	query := base.Order("user_id ASC")
+	query = filter.Pagination.Apply(query)
+
+	if err := query.Find(&memberships).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return memberships, total, nil
+}
+
+func (r *postgresMembershipRepository) Update(membership *models.Membership) error {
+	return r.db.Model(membership).Select("paid", "discounted").Updates(membership).Error
+}
+
+func (r *postgresMembershipRepository) Delete(id uuid.UUID, semesterID uuid.UUID) error {
+	result := r.db.Where("semester_id = ?", semesterID).Delete(&models.Membership{}, "id = ?", id)
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	if result.RowsAffected == 0 {
+		return store.ErrNotFound
+	}
+
+	return nil
+}

--- a/server/internal/store/postgres/membership.go
+++ b/server/internal/store/postgres/membership.go
@@ -83,7 +83,16 @@ func (r *postgresMembershipRepository) List(filter *models.ListMembershipsFilter
 }
 
 func (r *postgresMembershipRepository) Update(membership *models.Membership) error {
-	return r.db.Model(membership).Select("paid", "discounted").Updates(membership).Error
+	result := r.db.Model(membership).Select("paid", "discounted").Updates(membership)
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	if result.RowsAffected == 0 {
+		return store.ErrNotFound
+	}
+
+	return nil
 }
 
 func (r *postgresMembershipRepository) Delete(id uuid.UUID, semesterID uuid.UUID) error {

--- a/server/internal/store/postgres/membership_test.go
+++ b/server/internal/store/postgres/membership_test.go
@@ -1,0 +1,221 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMembershipRepository_CreateAndFindByID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	repo := postgres.NewMembershipRepository(db)
+
+	user, err := testutils.CreateTestUser(db, 20000001, "Jane", "Doe", "jane@example.com", "Math", "jdoe")
+	require.NoError(t, err)
+
+	semester, err := testutils.CreateTestSemester(db, "Fall 2026")
+	require.NoError(t, err)
+
+	membership := &models.Membership{
+		UserID:     user.ID,
+		SemesterID: semester.ID,
+		Paid:       true,
+		Discounted: false,
+	}
+
+	require.NoError(t, repo.Create(membership))
+	require.NotEqual(t, uuid.Nil, membership.ID)
+
+	found, err := repo.FindByID(membership.ID)
+	require.NoError(t, err)
+	require.Equal(t, membership.ID, found.ID)
+	require.Equal(t, user.ID, found.UserID)
+	require.Equal(t, semester.ID, found.SemesterID)
+	require.True(t, found.Paid)
+	require.False(t, found.Discounted)
+}
+
+func TestMembershipRepository_FindByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewMembershipRepository(container.GetDB())
+
+	_, err = repo.FindByID(uuid.New())
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMembershipRepository_FindByIDAndSemesterID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	repo := postgres.NewMembershipRepository(db)
+
+	user, err := testutils.CreateTestUser(db, 20000002, "John", "Smith", "john@example.com", "Science", "jsmith")
+	require.NoError(t, err)
+
+	semesterA, err := testutils.CreateTestSemester(db, "Fall 2026")
+	require.NoError(t, err)
+
+	semesterB, err := testutils.CreateTestSemester(db, "Winter 2027")
+	require.NoError(t, err)
+
+	membership, err := testutils.CreateTestMembership(db, user.ID, semesterA.ID)
+	require.NoError(t, err)
+
+	found, err := repo.FindByIDAndSemesterID(membership.ID, semesterA.ID)
+	require.NoError(t, err)
+	require.Equal(t, membership.ID, found.ID)
+
+	_, err = repo.FindByIDAndSemesterID(membership.ID, semesterB.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestMembershipRepository_List(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	repo := postgres.NewMembershipRepository(db)
+
+	semesterA, err := testutils.CreateTestSemester(db, "Fall 2026")
+	require.NoError(t, err)
+
+	semesterB, err := testutils.CreateTestSemester(db, "Winter 2027")
+	require.NoError(t, err)
+
+	user1, err := testutils.CreateTestUser(db, 20000010, "Alice", "A", "alice@example.com", "Math", "aa")
+	require.NoError(t, err)
+	user2, err := testutils.CreateTestUser(db, 20000011, "Bob", "B", "bob@example.com", "Math", "bb")
+	require.NoError(t, err)
+	user3, err := testutils.CreateTestUser(db, 20000012, "Cara", "C", "cara@example.com", "Math", "cc")
+	require.NoError(t, err)
+
+	m1 := &models.Membership{UserID: user1.ID, SemesterID: semesterA.ID, Paid: true, Discounted: false}
+	m2 := &models.Membership{UserID: user2.ID, SemesterID: semesterA.ID, Paid: false, Discounted: false}
+	m3 := &models.Membership{UserID: user3.ID, SemesterID: semesterB.ID, Paid: true, Discounted: false}
+	require.NoError(t, repo.Create(m1))
+	require.NoError(t, repo.Create(m2))
+	require.NoError(t, repo.Create(m3))
+
+	// Filter by semester only: expect m1 and m2, ordered by user ID ascending.
+	results, total, err := repo.List(&models.ListMembershipsFilter{SemesterID: &semesterA.ID})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total)
+	require.Len(t, results, 2)
+	require.Equal(t, user1.ID, results[0].UserID)
+	require.Equal(t, user2.ID, results[1].UserID)
+
+	// Filter by semester and paid status: expect only m1.
+	paidTrue := true
+	results, total, err = repo.List(&models.ListMembershipsFilter{SemesterID: &semesterA.ID, Paid: &paidTrue})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Len(t, results, 1)
+	require.Equal(t, m1.ID, results[0].ID)
+
+	// Pagination: limit 1, offset 1 within semester A returns the second member.
+	limit := 1
+	offset := 1
+	results, total, err = repo.List(&models.ListMembershipsFilter{
+		SemesterID: &semesterA.ID,
+		Pagination: models.Pagination{Limit: &limit, Offset: &offset},
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total)
+	require.Len(t, results, 1)
+	require.Equal(t, user2.ID, results[0].UserID)
+}
+
+func TestMembershipRepository_Update(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	repo := postgres.NewMembershipRepository(db)
+
+	user, err := testutils.CreateTestUser(db, 20000020, "Dana", "D", "dana@example.com", "Math", "dd")
+	require.NoError(t, err)
+
+	semester, err := testutils.CreateTestSemester(db, "Fall 2026")
+	require.NoError(t, err)
+
+	membership, err := testutils.CreateTestMembership(db, user.ID, semester.ID)
+	require.NoError(t, err)
+
+	membership.Paid = false
+	membership.Discounted = false
+	require.NoError(t, repo.Update(membership))
+
+	found, err := repo.FindByID(membership.ID)
+	require.NoError(t, err)
+	require.False(t, found.Paid)
+	require.False(t, found.Discounted)
+}
+
+func TestMembershipRepository_Delete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	repo := postgres.NewMembershipRepository(db)
+
+	user, err := testutils.CreateTestUser(db, 20000030, "Eli", "E", "eli@example.com", "Math", "ee")
+	require.NoError(t, err)
+
+	semesterA, err := testutils.CreateTestSemester(db, "Fall 2026")
+	require.NoError(t, err)
+
+	semesterB, err := testutils.CreateTestSemester(db, "Winter 2027")
+	require.NoError(t, err)
+
+	membership, err := testutils.CreateTestMembership(db, user.ID, semesterA.ID)
+	require.NoError(t, err)
+
+	// Deleting with the wrong semester ID should not find the row.
+	err = repo.Delete(membership.ID, semesterB.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.NoError(t, repo.Delete(membership.ID, semesterA.ID))
+
+	_, err = repo.FindByID(membership.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	err = repo.Delete(membership.ID, semesterA.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/postgres/membership_test.go
+++ b/server/internal/store/postgres/membership_test.go
@@ -184,6 +184,20 @@ func TestMembershipRepository_Update(t *testing.T) {
 	require.False(t, found.Discounted)
 }
 
+func TestMembershipRepository_Update_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewMembershipRepository(container.GetDB())
+
+	err = repo.Update(&models.Membership{ID: uuid.New()})
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
 func TestMembershipRepository_Delete(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/store/postgres/store.go
+++ b/server/internal/store/postgres/store.go
@@ -43,10 +43,11 @@ var _ store.Store = (*PostgresStore)(nil)
 
 func NewStore(db *gorm.DB) store.Store {
 	return &PostgresStore{
-		db:        db,
-		semesters: NewSemesterRepository(db),
-		members: 	NewMemberRepository(db),
-    structures: NewStructureRepository(db),
+		db:          db,
+		semesters:   NewSemesterRepository(db),
+		memberships: NewMembershipRepository(db),
+		members:     NewMemberRepository(db),
+		structures:  NewStructureRepository(db),
 	}
 }
 
@@ -93,10 +94,11 @@ func (s *PostgresStore) BeginTx() (store.Store, error) {
 	}
 
 	return &PostgresStore{
-		db:        tx,
-		semesters: NewSemesterRepository(tx),
-		members:   NewMemberRepository(tx),
-    structures: NewStructureRepository(tx),
+		db:          tx,
+		semesters:   NewSemesterRepository(tx),
+		memberships: NewMembershipRepository(tx),
+		members:     NewMemberRepository(tx),
+		structures:  NewStructureRepository(tx),
 	}, nil
 }
 

--- a/server/internal/store/postgres/store_test.go
+++ b/server/internal/store/postgres/store_test.go
@@ -1,0 +1,66 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Memberships(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	s := postgres.NewStore(db)
+
+	user, err := testutils.CreateTestUser(db, 20000040, "Fay", "F", "fay@example.com", "Math", "ff")
+	require.NoError(t, err)
+
+	semester, err := testutils.CreateTestSemester(db, "Fall 2026")
+	require.NoError(t, err)
+
+	membership := &models.Membership{UserID: user.ID, SemesterID: semester.ID, Paid: true}
+	require.NoError(t, s.Memberships().Create(membership))
+
+	found, err := s.Memberships().FindByID(membership.ID)
+	require.NoError(t, err)
+	require.Equal(t, membership.ID, found.ID)
+}
+
+func TestStore_BeginTx_Memberships_Rollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	s := postgres.NewStore(db)
+
+	user, err := testutils.CreateTestUser(db, 20000041, "Gus", "G", "gus@example.com", "Math", "gg")
+	require.NoError(t, err)
+
+	semester, err := testutils.CreateTestSemester(db, "Fall 2026")
+	require.NoError(t, err)
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	membership := &models.Membership{UserID: user.ID, SemesterID: semester.ID, Paid: true}
+	require.NoError(t, tx.Memberships().Create(membership))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Memberships().FindByID(membership.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}


### PR DESCRIPTION
## Summary

- Implements `store.MembershipRepository` (Postgres and in-memory), following the pattern established by `StructureRepository`
- Wires the repository into both `PostgresStore` and `InMemoryStore`, including transaction/`clone()` handling for `BeginTx`/`Commit`/`Rollback`
- The repository only covers columns native to the `memberships` table (`id`, `user_id`, `semester_id`, `paid`, `discounted`); joined filtering (name/email/faculty/search) used today by `membership_service.go` stays in the service layer, since migrating that caller is out of scope for this change
- Fixes two behavioral inconsistencies surfaced during review before merge:
  - Postgres `Update()` now returns `store.ErrNotFound` when no row matches, matching the in-memory implementation
  - In-memory `Create()` now rejects a duplicate `(UserID, SemesterID)` pair, matching the Postgres `user_semester_unique` index

`membership_service.go` and the memberships controller/handler are untouched — this PR only adds the repository layer.

## Test plan

- [x] `go test -C server ./internal/store/... -p=1` — all passing (Postgres tests run against a real container via testcontainers)
- [x] `go build -C server ./...` and `go vet -C server ./internal/store/...` — clean
- [x] `gofmt -l` — clean

Closes #350