### PR TITLE
Implement event repository

### DIFF
--- a/server/internal/store/event.go
+++ b/server/internal/store/event.go
@@ -1,4 +1,32 @@
 package store
 
-// EventRepository is the interface for accessing the events in the data store. It provides methods for creating, reading, updating, and deleting events.
-type EventRepository interface {}
+import (
+	"api/internal/models"
+
+	"github.com/google/uuid"
+)
+
+// EventRepository is the interface for accessing the events in the data store. It provides methods for creating, reading, updating, and listing events.
+type EventRepository interface {
+	// Create creates a new event in the data store.
+	Create(event *models.Event) error
+
+	// FindByID retrieves an event from the data store by its ID, preloaded with
+	// its semester, structure (with blinds), and entries.
+	FindByID(id int32) (models.Event, error)
+
+	// FindBySemesterAndID retrieves an event from the data store scoped to a
+	// specific semester, preloaded with its semester, structure (with blinds),
+	// and entries. It returns store.ErrNotFound if no event with the given ID
+	// exists within the given semester.
+	FindBySemesterAndID(semesterID uuid.UUID, id int32) (models.Event, error)
+
+	// List retrieves events matching the given filter (semester, optional name
+	// search), ordered by start date descending, along with the total matching
+	// count before pagination is applied.
+	List(filter *models.ListEventsFilter) ([]models.Event, int64, error)
+
+	// Update applies a partial update to an event using the given column/value
+	// map, and writes the applied values back onto event.
+	Update(event *models.Event, values map[string]any) error
+}

--- a/server/internal/store/inmemory/event.go
+++ b/server/internal/store/inmemory/event.go
@@ -1,0 +1,161 @@
+package inmemory
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type inMemoryEventRepository struct {
+	mu     sync.RWMutex
+	events map[int32]*models.Event
+	nextID int32
+}
+
+var _ store.EventRepository = (*inMemoryEventRepository)(nil)
+
+func newEventRepository() *inMemoryEventRepository {
+	return &inMemoryEventRepository{
+		events: make(map[int32]*models.Event),
+	}
+}
+
+func NewEventRepository() store.EventRepository {
+	return newEventRepository()
+}
+
+func (r *inMemoryEventRepository) clone() *inMemoryEventRepository {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	c := &inMemoryEventRepository{
+		events: make(map[int32]*models.Event, len(r.events)),
+		nextID: r.nextID,
+	}
+	for id, e := range r.events {
+		ec := *e
+		c.events[id] = &ec
+	}
+	return c
+}
+
+func (r *inMemoryEventRepository) Create(event *models.Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if event.ID == 0 {
+		r.nextID++
+		event.ID = r.nextID
+	} else if _, exists := r.events[event.ID]; exists {
+		return fmt.Errorf("event with ID %d already exists", event.ID)
+	}
+
+	copy := *event
+	r.events[event.ID] = &copy
+
+	return nil
+}
+
+func (r *inMemoryEventRepository) FindByID(id int32) (models.Event, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	event, exists := r.events[id]
+	if !exists {
+		return models.Event{}, store.ErrNotFound
+	}
+
+	return *event, nil
+}
+
+func (r *inMemoryEventRepository) FindBySemesterAndID(semesterID uuid.UUID, id int32) (models.Event, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	event, exists := r.events[id]
+	if !exists || event.SemesterID != semesterID {
+		return models.Event{}, store.ErrNotFound
+	}
+
+	return *event, nil
+}
+
+func (r *inMemoryEventRepository) List(filter *models.ListEventsFilter) ([]models.Event, int64, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var events []models.Event
+	for _, event := range r.events {
+		if event.SemesterID != filter.SemesterID {
+			continue
+		}
+		if filter.Search != "" &&
+			!strings.Contains(strings.ToLower(event.Name), strings.ToLower(filter.Search)) {
+			continue
+		}
+		events = append(events, *event)
+	}
+
+	sort.Slice(events, func(i, j int) bool {
+		return events[i].StartDate.After(events[j].StartDate)
+	})
+
+	total := int64(len(events))
+
+	offset := 0
+	if filter.Pagination.Offset != nil && *filter.Pagination.Offset > 0 {
+		offset = *filter.Pagination.Offset
+	}
+
+	if offset >= len(events) {
+		return []models.Event{}, total, nil
+	}
+
+	events = events[offset:]
+
+	if filter.Pagination.Limit != nil && *filter.Pagination.Limit > 0 &&
+		*filter.Pagination.Limit < len(events) {
+		events = events[:*filter.Pagination.Limit]
+	}
+
+	return events, total, nil
+}
+
+func (r *inMemoryEventRepository) Update(event *models.Event, values map[string]any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	existing, exists := r.events[event.ID]
+	if !exists {
+		return store.ErrNotFound
+	}
+
+	for key, value := range values {
+		switch key {
+		case "name":
+			existing.Name = value.(string)
+		case "format":
+			existing.Format = value.(string)
+		case "notes":
+			if value == nil {
+				existing.Notes = ""
+			} else {
+				existing.Notes = value.(string)
+			}
+		case "start_date":
+			existing.StartDate = value.(time.Time)
+		case "points_multiplier":
+			existing.PointsMultiplier = value.(float32)
+		}
+	}
+
+	*event = *existing
+
+	return nil
+}

--- a/server/internal/store/inmemory/event_store_test.go
+++ b/server/internal/store/inmemory/event_store_test.go
@@ -1,0 +1,64 @@
+package inmemory
+
+import (
+	"testing"
+
+	"api/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Events(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+	semesterID := uuid.New()
+
+	event := newTestEvent(semesterID, 1, "Store Wiring Event")
+	require.NoError(t, s.Events().Create(event))
+
+	found, err := s.Events().FindByID(event.ID)
+	require.NoError(t, err)
+	require.Equal(t, event.ID, found.ID)
+}
+
+func TestStore_BeginTx_Events_Commit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+	semesterID := uuid.New()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	event := newTestEvent(semesterID, 1, "Committed Event")
+	require.NoError(t, tx.Events().Create(event))
+
+	// The parent store must not see the event until Commit is called.
+	_, err = s.Events().FindByID(event.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.NoError(t, tx.Commit())
+
+	found, err := s.Events().FindByID(event.ID)
+	require.NoError(t, err)
+	require.Equal(t, event.ID, found.ID)
+}
+
+func TestStore_BeginTx_Events_DiscardedWithoutCommit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+	semesterID := uuid.New()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	event := newTestEvent(semesterID, 1, "Uncommitted Event")
+	require.NoError(t, tx.Events().Create(event))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Events().FindByID(event.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/inmemory/event_test.go
+++ b/server/internal/store/inmemory/event_test.go
@@ -1,0 +1,170 @@
+package inmemory
+
+import (
+	"testing"
+	"time"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestEvent(semesterID uuid.UUID, structureID int32, name string) *models.Event {
+	return &models.Event{
+		Name:             name,
+		Format:           "No Limit Hold'em",
+		SemesterID:       semesterID,
+		StartDate:        time.Date(2024, 10, 1, 18, 0, 0, 0, time.UTC),
+		StructureID:      structureID,
+		PointsMultiplier: 1.0,
+	}
+}
+
+func TestEventRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	repo := newEventRepository()
+	semesterID := uuid.New()
+
+	event := newTestEvent(semesterID, 1, "Test Event")
+	require.NoError(t, repo.Create(event))
+	require.NotZero(t, event.ID)
+}
+
+func TestEventRepository_FindByID(t *testing.T) {
+	t.Parallel()
+
+	repo := newEventRepository()
+	semesterID := uuid.New()
+
+	event := newTestEvent(semesterID, 1, "Findable Event")
+	require.NoError(t, repo.Create(event))
+
+	found, err := repo.FindByID(event.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Findable Event", found.Name)
+
+	_, err = repo.FindByID(99999)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEventRepository_Create_DuplicateID(t *testing.T) {
+	t.Parallel()
+
+	repo := newEventRepository()
+	semesterID := uuid.New()
+
+	event := newTestEvent(semesterID, 1, "First")
+	require.NoError(t, repo.Create(event))
+
+	dup := newTestEvent(semesterID, 1, "Second")
+	dup.ID = event.ID
+	err := repo.Create(dup)
+	require.Error(t, err)
+}
+
+func TestEventRepository_FindBySemesterAndID(t *testing.T) {
+	t.Parallel()
+
+	repo := newEventRepository()
+	semesterID := uuid.New()
+	otherSemesterID := uuid.New()
+
+	event := newTestEvent(semesterID, 1, "Scoped Event")
+	require.NoError(t, repo.Create(event))
+
+	found, err := repo.FindBySemesterAndID(semesterID, event.ID)
+	require.NoError(t, err)
+	require.Equal(t, event.ID, found.ID)
+
+	_, err = repo.FindBySemesterAndID(otherSemesterID, event.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEventRepository_List(t *testing.T) {
+	t.Parallel()
+
+	repo := newEventRepository()
+	semesterID := uuid.New()
+
+	require.NoError(t, repo.Create(newTestEvent(semesterID, 1, "Alpha Tournament")))
+	require.NoError(t, repo.Create(newTestEvent(semesterID, 1, "Beta Tournament")))
+	require.NoError(t, repo.Create(newTestEvent(uuid.New(), 1, "Other Semester Event")))
+
+	events, total, err := repo.List(&models.ListEventsFilter{SemesterID: semesterID})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total)
+	require.Len(t, events, 2)
+
+	events, total, err = repo.List(&models.ListEventsFilter{SemesterID: semesterID, Search: "alpha"})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Equal(t, "Alpha Tournament", events[0].Name)
+}
+
+func TestEventRepository_Update(t *testing.T) {
+	t.Parallel()
+
+	repo := newEventRepository()
+	semesterID := uuid.New()
+
+	event := newTestEvent(semesterID, 1, "Original Name")
+	require.NoError(t, repo.Create(event))
+
+	err := repo.Update(event, map[string]any{
+		"name":              "Updated Name",
+		"points_multiplier": float32(2.0),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "Updated Name", event.Name)
+	require.Equal(t, float32(2.0), event.PointsMultiplier)
+
+	found, err := repo.FindByID(event.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Updated Name", found.Name)
+}
+
+func TestEventRepository_Update_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := newEventRepository()
+
+	err := repo.Update(&models.Event{ID: 99999}, map[string]any{"name": "X"})
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEventRepository_Clone_Isolation(t *testing.T) {
+	t.Parallel()
+
+	repo := newEventRepository()
+	semesterID := uuid.New()
+
+	event := newTestEvent(semesterID, 1, "Original Name")
+	require.NoError(t, repo.Create(event))
+
+	clone := repo.clone()
+
+	// Mutating the clone must not affect the original.
+	require.NoError(t, clone.Update(&models.Event{ID: event.ID}, map[string]any{"name": "Cloned Name"}))
+
+	original, err := repo.FindByID(event.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Original Name", original.Name)
+
+	cloned, err := clone.FindByID(event.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Cloned Name", cloned.Name)
+
+	// Creating a new event on the original must not appear in the clone.
+	require.NoError(t, repo.Create(newTestEvent(semesterID, 1, "Second Event")))
+
+	_, cloneTotal, err := clone.List(&models.ListEventsFilter{SemesterID: semesterID})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, cloneTotal)
+
+	_, originalTotal, err := repo.List(&models.ListEventsFilter{SemesterID: semesterID})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, originalTotal)
+}

--- a/server/internal/store/inmemory/store.go
+++ b/server/internal/store/inmemory/store.go
@@ -11,6 +11,7 @@ type InMemoryStore struct {
 	members     *inMemoryMemberRepository
 	memberships *inMemoryMembershipRepository
 	structures  *inMemoryStructureRepository
+	events      *inMemoryEventRepository
 	parent      *InMemoryStore
 }
 
@@ -22,6 +23,7 @@ func NewStore() store.Store {
 		members:     newMemberRepository(),
 		memberships: newMembershipRepository(),
 		structures:  newStructureRepository(),
+		events:      newEventRepository(),
 	}
 }
 
@@ -49,7 +51,12 @@ func (s *InMemoryStore) Memberships() store.MembershipRepository {
 	return s.memberships
 }
 
-func (s *InMemoryStore) Events() store.EventRepository     { return nil }
+func (s *InMemoryStore) Events() store.EventRepository {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.events
+}
+
 func (s *InMemoryStore) Entries() store.EntryRepository    { return nil }
 func (s *InMemoryStore) Rankings() store.RankingRepository { return nil }
 func (s *InMemoryStore) Logins() store.LoginRepository     { return nil }
@@ -75,6 +82,9 @@ func (s *InMemoryStore) BeginTx() (store.Store, error) {
 	if s.semesters != nil {
 		tx.semesters = s.semesters.clone()
 	}
+	if s.events != nil {
+		tx.events = s.events.clone()
+	}
 	return tx, nil
 }
 
@@ -96,6 +106,9 @@ func (s *InMemoryStore) Commit() error {
 	}
 	if s.semesters != nil {
 		s.parent.semesters = s.semesters
+	}
+	if s.events != nil {
+		s.parent.events = s.events
 	}
 	return nil
 }

--- a/server/internal/store/postgres/event.go
+++ b/server/internal/store/postgres/event.go
@@ -1,0 +1,105 @@
+package postgres
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type postgresEventRepository struct {
+	db *gorm.DB
+}
+
+var _ store.EventRepository = (*postgresEventRepository)(nil)
+
+func NewEventRepository(db *gorm.DB) store.EventRepository {
+	return &postgresEventRepository{db: db}
+}
+
+// eventNameLikeReplacer escapes ILIKE special characters in user-supplied
+// search input, mirroring services.sanitizeLikeInput.
+var eventNameLikeReplacer = strings.NewReplacer(
+	"\\", "\\\\",
+	"%", "\\%",
+	"_", "\\_",
+)
+
+func (r *postgresEventRepository) Create(event *models.Event) error {
+	return r.db.Create(event).Error
+}
+
+func (r *postgresEventRepository) FindByID(id int32) (models.Event, error) {
+	event := models.Event{ID: id}
+
+	res := event.Preload(r.db, models.EventPreloadOptions{
+		Semester:  true,
+		Structure: true,
+		Entries:   true,
+	}).First(&event)
+	if err := res.Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Event{}, store.ErrNotFound
+		}
+		return models.Event{}, err
+	}
+
+	return event, nil
+}
+
+func (r *postgresEventRepository) FindBySemesterAndID(semesterID uuid.UUID, id int32) (models.Event, error) {
+	var event models.Event
+
+	query := models.Event{}.Preload(r.db, models.EventPreloadOptions{
+		Semester:  true,
+		Structure: true,
+		Entries:   true,
+	}).
+		Where(`"Semester"."id" = ?`, semesterID).
+		Where("events.id = ?", id)
+
+	res := query.First(&event)
+	if err := res.Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Event{}, store.ErrNotFound
+		}
+		return models.Event{}, err
+	}
+
+	return event, nil
+}
+
+func (r *postgresEventRepository) List(filter *models.ListEventsFilter) ([]models.Event, int64, error) {
+	applyFilter := func(q *gorm.DB) *gorm.DB {
+		q = q.Where("semester_id = ?", filter.SemesterID)
+		if filter.Search != "" {
+			pattern := "%" + eventNameLikeReplacer.Replace(filter.Search) + "%"
+			q = q.Where("name ILIKE ?", pattern)
+		}
+		return q
+	}
+
+	var total int64
+	if err := applyFilter(r.db.Model(&models.Event{})).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	query := applyFilter(models.Event{}.Preload(r.db, models.EventPreloadOptions{Entries: true})).
+		Order("start_date DESC")
+	query = filter.Pagination.Apply(query)
+
+	var events []models.Event
+	if err := query.Find(&events).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return events, total, nil
+}
+
+func (r *postgresEventRepository) Update(event *models.Event, values map[string]any) error {
+	return r.db.Omit(clause.Associations).Model(event).Updates(values).Error
+}

--- a/server/internal/store/postgres/event_store_test.go
+++ b/server/internal/store/postgres/event_store_test.go
@@ -1,0 +1,75 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Events(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+
+	s := postgres.NewStore(db)
+
+	event := &models.Event{
+		Name:             "Store Wiring Event",
+		Format:           "No Limit Hold'em",
+		SemesterID:       testutils.TEST_SEMESTERS[0].ID,
+		StartDate:        time.Date(2024, 10, 1, 18, 0, 0, 0, time.UTC),
+		StructureID:      testutils.TEST_STRUCTURES[0].ID,
+		PointsMultiplier: 1.0,
+	}
+	require.NoError(t, s.Events().Create(event))
+
+	found, err := s.Events().FindByID(event.ID)
+	require.NoError(t, err)
+	require.Equal(t, event.ID, found.ID)
+}
+
+func TestStore_BeginTx_Events_Rollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+
+	s := postgres.NewStore(db)
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	event := &models.Event{
+		Name:             "Rolled Back Event",
+		Format:           "No Limit Hold'em",
+		SemesterID:       testutils.TEST_SEMESTERS[0].ID,
+		StartDate:        time.Date(2024, 10, 1, 18, 0, 0, 0, time.UTC),
+		StructureID:      testutils.TEST_STRUCTURES[0].ID,
+		PointsMultiplier: 1.0,
+	}
+	require.NoError(t, tx.Events().Create(event))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Events().FindByID(event.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/postgres/event_test.go
+++ b/server/internal/store/postgres/event_test.go
@@ -1,0 +1,191 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+
+	repo := postgres.NewEventRepository(db)
+
+	event := &models.Event{
+		Name:             "Test Event",
+		Format:           "No Limit Hold'em",
+		SemesterID:       testutils.TEST_SEMESTERS[0].ID,
+		StartDate:        time.Date(2024, 10, 1, 18, 0, 0, 0, time.UTC),
+		StructureID:      testutils.TEST_STRUCTURES[0].ID,
+		PointsMultiplier: 1.0,
+	}
+
+	require.NoError(t, repo.Create(event))
+	require.NotZero(t, event.ID)
+}
+
+func TestEventRepository_FindByID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+
+	repo := postgres.NewEventRepository(db)
+
+	created, err := testutils.CreateTestEvent(
+		db,
+		testutils.TEST_SEMESTERS[0].ID,
+		testutils.TEST_STRUCTURES[0].ID,
+		"Findable Event",
+	)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, found.ID)
+	require.Equal(t, "Findable Event", found.Name)
+	require.NotNil(t, found.Semester)
+	require.NotNil(t, found.Structure)
+}
+
+func TestEventRepository_FindByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewEventRepository(container.GetDB())
+
+	_, err = repo.FindByID(99999)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEventRepository_FindBySemesterAndID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+
+	repo := postgres.NewEventRepository(db)
+
+	created, err := testutils.CreateTestEvent(
+		db,
+		testutils.TEST_SEMESTERS[0].ID,
+		testutils.TEST_STRUCTURES[0].ID,
+		"Scoped Event",
+	)
+	require.NoError(t, err)
+
+	found, err := repo.FindBySemesterAndID(testutils.TEST_SEMESTERS[0].ID, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, found.ID)
+	require.Equal(t, "Scoped Event", found.Name)
+	require.NotNil(t, found.Semester)
+	require.NotNil(t, found.Structure)
+
+	_, err = repo.FindBySemesterAndID(testutils.TEST_SEMESTERS[1].ID, created.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	_, err = repo.FindBySemesterAndID(testutils.TEST_SEMESTERS[0].ID, 99999)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEventRepository_List(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+
+	repo := postgres.NewEventRepository(db)
+
+	semesterID := testutils.TEST_SEMESTERS[0].ID
+	_, err = testutils.CreateTestEvent(db, semesterID, testutils.TEST_STRUCTURES[0].ID, "Alpha Tournament")
+	require.NoError(t, err)
+	_, err = testutils.CreateTestEvent(db, semesterID, testutils.TEST_STRUCTURES[0].ID, "Beta Tournament")
+	require.NoError(t, err)
+	_, err = testutils.CreateTestEvent(
+		db,
+		testutils.TEST_SEMESTERS[1].ID,
+		testutils.TEST_STRUCTURES[0].ID,
+		"Other Semester Event",
+	)
+	require.NoError(t, err)
+
+	events, total, err := repo.List(&models.ListEventsFilter{SemesterID: semesterID})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total)
+	require.Len(t, events, 2)
+
+	events, total, err = repo.List(&models.ListEventsFilter{SemesterID: semesterID, Search: "Alpha"})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+	require.Len(t, events, 1)
+	require.Equal(t, "Alpha Tournament", events[0].Name)
+}
+
+func TestEventRepository_Update(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+
+	repo := postgres.NewEventRepository(db)
+
+	created, err := testutils.CreateTestEvent(
+		db,
+		testutils.TEST_SEMESTERS[0].ID,
+		testutils.TEST_STRUCTURES[0].ID,
+		"Original Name",
+	)
+	require.NoError(t, err)
+
+	err = repo.Update(created, map[string]any{"name": "Updated Name"})
+	require.NoError(t, err)
+	require.Equal(t, "Updated Name", created.Name)
+
+	found, err := repo.FindByID(created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "Updated Name", found.Name)
+}

--- a/server/internal/store/postgres/store.go
+++ b/server/internal/store/postgres/store.go
@@ -48,6 +48,7 @@ func NewStore(db *gorm.DB) store.Store {
 		memberships: NewMembershipRepository(db),
 		members:     NewMemberRepository(db),
 		structures:  NewStructureRepository(db),
+		events:      NewEventRepository(db),
 	}
 }
 
@@ -99,6 +100,7 @@ func (s *PostgresStore) BeginTx() (store.Store, error) {
 		memberships: NewMembershipRepository(tx),
 		members:     NewMemberRepository(tx),
 		structures:  NewStructureRepository(tx),
+		events:      NewEventRepository(tx),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Implements `store.EventRepository` (Postgres and in-memory) following the pattern established by `MembershipRepository`/`StructureRepository`, and wires it into both `Store` implementations. Query behavior is modeled on the v2 controller-facing methods (`CreateEventV2`, `GetEventByID`, `ListEventsV2`, `UpdateEventV2`); `events_service.go`, `controller/events.go`, and `server/events_handler.go` are untouched.

- Define `store.EventRepository` interface: `Create`, `FindByID`, `FindBySemesterAndID`, `List`, `Update`
- Implement `postgresEventRepository` (GORM-backed, with `Semester`/`Structure`/`Entries` preloading)
- Implement `inMemoryEventRepository` (map-backed, with `clone()` for transaction isolation)
- Wire `Events()` into `PostgresStore` and `InMemoryStore`, including `BeginTx`/`Commit`/`Rollback`

Closes uwpokerclub/website#351

## Test plan

- [x] `go test -C server ./internal/store/postgres/... -p=1` — all repository and store-wiring tests pass, including rollback isolation
- [x] `go test -C server ./internal/store/inmemory/... -p=1` — all repository and store-wiring tests pass, including `clone()` isolation and commit/rollback behavior
- [x] `go build -C server ./...` and `go vet -C server ./...` pass
- [x] Confirmed `events_service.go`, `controller/events.go`, and `server/events_handler.go` are unmodified