### PR TITLE
Implement EntryRepository (Postgres and in-memory)

### DIFF
--- a/server/internal/models/participant.go
+++ b/server/internal/models/participant.go
@@ -45,6 +45,19 @@ type DeleteParticipantRequest struct {
 	EventID      int32     `json:"eventId" binding:"required"`
 }
 
+// ListParticipantsFilter is the set of parameters that will be used to filter the
+// list entries query. EventID must be set by the caller; the zero value for the
+// embedded Pagination is the same as not paginating the result. Filtering by
+// participant/user name or student number requires a join against the memberships
+// and users tables and is not performed at this layer -- callers needing that
+// filtering continue to use the service layer for now.
+type ListParticipantsFilter struct {
+	Pagination
+
+	// EventID is the ID of the event to list entries for.
+	EventID int32
+}
+
 type ListParticipantsResult struct {
 	ID           int32      `json:"id"`
 	MembershipId uuid.UUID  `json:"membershipId"`

--- a/server/internal/store/entry.go
+++ b/server/internal/store/entry.go
@@ -1,4 +1,36 @@
 package store
 
-// EntryRepository is the interface for accessing the entries in the data store. It provides methods for creating, reading, updating, and deleting entries.
-type EntryRepository interface {}
+import (
+	"api/internal/models"
+
+	"github.com/google/uuid"
+)
+
+// EntryRepository is the interface for accessing the entries (event participants) in the data store.
+// It provides methods for creating, reading, updating, listing, and deleting entries.
+type EntryRepository interface {
+	// Create creates a new entry in the data store.
+	Create(participant *models.Participant) error
+
+	// FindByID retrieves an entry from the data store by its ID.
+	FindByID(id int32) (models.Participant, error)
+
+	// FindByMembershipAndEventID retrieves an entry from the data store by its membership ID,
+	// scoped to a specific event. It returns store.ErrNotFound if no entry exists for the given
+	// membership within the given event.
+	FindByMembershipAndEventID(membershipID uuid.UUID, eventID int32) (models.Participant, error)
+
+	// List retrieves entries for a given event, preloaded with their membership (and the
+	// membership's user, semester, and ranking), ordered by signed-out time descending
+	// (entries that have not yet signed out sort first), along with the total matching count
+	// before pagination is applied.
+	List(filter *models.ListParticipantsFilter) ([]models.Participant, int64, error)
+
+	// Update applies a partial update to an entry using the given column/value map, and writes
+	// the applied values back onto participant.
+	Update(participant *models.Participant, values map[string]any) error
+
+	// Delete deletes an entry from the data store by its membership ID, scoped to a specific
+	// event. Returns store.ErrNotFound if no matching record exists.
+	Delete(membershipID uuid.UUID, eventID int32) error
+}

--- a/server/internal/store/inmemory/entry.go
+++ b/server/internal/store/inmemory/entry.go
@@ -1,0 +1,184 @@
+package inmemory
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type inMemoryEntryRepository struct {
+	mu           sync.RWMutex
+	participants map[int32]*models.Participant
+	nextID       int32
+}
+
+var _ store.EntryRepository = (*inMemoryEntryRepository)(nil)
+
+func newEntryRepository() *inMemoryEntryRepository {
+	return &inMemoryEntryRepository{
+		participants: make(map[int32]*models.Participant),
+	}
+}
+
+func NewEntryRepository() store.EntryRepository {
+	return newEntryRepository()
+}
+
+func (r *inMemoryEntryRepository) clone() *inMemoryEntryRepository {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	c := &inMemoryEntryRepository{
+		participants: make(map[int32]*models.Participant, len(r.participants)),
+		nextID:       r.nextID,
+	}
+	for id, p := range r.participants {
+		pc := *p
+		c.participants[id] = &pc
+	}
+	return c
+}
+
+func (r *inMemoryEntryRepository) Create(participant *models.Participant) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if participant.ID == 0 {
+		r.nextID++
+		participant.ID = r.nextID
+	} else if _, exists := r.participants[participant.ID]; exists {
+		return fmt.Errorf("entry with ID %d already exists", participant.ID)
+	}
+
+	if participant.MembershipID != nil {
+		for _, p := range r.participants {
+			if p.MembershipID != nil && *p.MembershipID == *participant.MembershipID && p.EventID == participant.EventID {
+				return fmt.Errorf(
+					"entry for membership %s in event %d already exists",
+					*participant.MembershipID, participant.EventID,
+				)
+			}
+		}
+	}
+
+	copy := *participant
+	r.participants[participant.ID] = &copy
+
+	return nil
+}
+
+func (r *inMemoryEntryRepository) FindByID(id int32) (models.Participant, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	participant, exists := r.participants[id]
+	if !exists {
+		return models.Participant{}, store.ErrNotFound
+	}
+
+	return *participant, nil
+}
+
+func (r *inMemoryEntryRepository) FindByMembershipAndEventID(membershipID uuid.UUID, eventID int32) (models.Participant, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, p := range r.participants {
+		if p.MembershipID != nil && *p.MembershipID == membershipID && p.EventID == eventID {
+			return *p, nil
+		}
+	}
+
+	return models.Participant{}, store.ErrNotFound
+}
+
+func (r *inMemoryEntryRepository) List(filter *models.ListParticipantsFilter) ([]models.Participant, int64, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var participants []models.Participant
+	for _, p := range r.participants {
+		if p.EventID != filter.EventID {
+			continue
+		}
+		participants = append(participants, *p)
+	}
+
+	// Matches "ORDER BY signed_out_at DESC" under Postgres' default NULLS FIRST-on-DESC
+	// behavior: not-yet-signed-out entries (nil) sort first, then signed-out entries by
+	// most recent first.
+	sort.Slice(participants, func(i, j int) bool {
+		a, b := participants[i].SignedOutAt, participants[j].SignedOutAt
+		switch {
+		case a == nil && b == nil:
+			return false
+		case a == nil:
+			return true
+		case b == nil:
+			return false
+		default:
+			return a.After(*b)
+		}
+	})
+
+	total := int64(len(participants))
+
+	offset := 0
+	if filter.Pagination.Offset != nil && *filter.Pagination.Offset > 0 {
+		offset = *filter.Pagination.Offset
+	}
+
+	if offset >= len(participants) {
+		return []models.Participant{}, total, nil
+	}
+
+	participants = participants[offset:]
+
+	if filter.Pagination.Limit != nil && *filter.Pagination.Limit > 0 &&
+		*filter.Pagination.Limit < len(participants) {
+		participants = participants[:*filter.Pagination.Limit]
+	}
+
+	return participants, total, nil
+}
+
+func (r *inMemoryEntryRepository) Update(participant *models.Participant, values map[string]any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	existing, exists := r.participants[participant.ID]
+	if !exists {
+		return store.ErrNotFound
+	}
+
+	if v, ok := values["signed_out_at"]; ok {
+		if v == nil {
+			existing.SignedOutAt = nil
+		} else {
+			existing.SignedOutAt = v.(*time.Time)
+		}
+	}
+
+	*participant = *existing
+
+	return nil
+}
+
+func (r *inMemoryEntryRepository) Delete(membershipID uuid.UUID, eventID int32) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for id, p := range r.participants {
+		if p.MembershipID != nil && *p.MembershipID == membershipID && p.EventID == eventID {
+			delete(r.participants, id)
+			return nil
+		}
+	}
+
+	return store.ErrNotFound
+}

--- a/server/internal/store/inmemory/entry_store_test.go
+++ b/server/internal/store/inmemory/entry_store_test.go
@@ -1,0 +1,61 @@
+package inmemory
+
+import (
+	"testing"
+
+	"api/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Entries(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	participant := newTestParticipant(uuid.New(), 1)
+	require.NoError(t, s.Entries().Create(participant))
+
+	found, err := s.Entries().FindByID(participant.ID)
+	require.NoError(t, err)
+	require.Equal(t, participant.ID, found.ID)
+}
+
+func TestStore_BeginTx_Entries_Commit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	participant := newTestParticipant(uuid.New(), 1)
+	require.NoError(t, tx.Entries().Create(participant))
+
+	// The parent store must not see the entry until Commit is called.
+	_, err = s.Entries().FindByID(participant.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.NoError(t, tx.Commit())
+
+	found, err := s.Entries().FindByID(participant.ID)
+	require.NoError(t, err)
+	require.Equal(t, participant.ID, found.ID)
+}
+
+func TestStore_BeginTx_Entries_DiscardedWithoutCommit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	participant := newTestParticipant(uuid.New(), 1)
+	require.NoError(t, tx.Entries().Create(participant))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Entries().FindByID(participant.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/inmemory/entry_test.go
+++ b/server/internal/store/inmemory/entry_test.go
@@ -1,0 +1,200 @@
+package inmemory
+
+import (
+	"testing"
+	"time"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestParticipant(membershipID uuid.UUID, eventID int32) *models.Participant {
+	return &models.Participant{
+		MembershipID: &membershipID,
+		EventID:      eventID,
+	}
+}
+
+func TestEntryRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+
+	participant := newTestParticipant(uuid.New(), 1)
+	require.NoError(t, repo.Create(participant))
+	require.NotZero(t, participant.ID)
+}
+
+func TestEntryRepository_Create_DuplicateMembershipEvent(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+	membershipID := uuid.New()
+
+	require.NoError(t, repo.Create(newTestParticipant(membershipID, 1)))
+
+	err := repo.Create(newTestParticipant(membershipID, 1))
+	require.Error(t, err)
+}
+
+func TestEntryRepository_FindByID(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+
+	participant := newTestParticipant(uuid.New(), 1)
+	require.NoError(t, repo.Create(participant))
+
+	found, err := repo.FindByID(participant.ID)
+	require.NoError(t, err)
+	require.Equal(t, participant.ID, found.ID)
+
+	_, err = repo.FindByID(99999)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEntryRepository_FindByMembershipAndEventID(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+	membershipID := uuid.New()
+
+	created := newTestParticipant(membershipID, 1)
+	require.NoError(t, repo.Create(created))
+
+	found, err := repo.FindByMembershipAndEventID(membershipID, 1)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, found.ID)
+
+	_, err = repo.FindByMembershipAndEventID(membershipID, 2)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	_, err = repo.FindByMembershipAndEventID(uuid.New(), 1)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEntryRepository_List(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+
+	stillIn := newTestParticipant(uuid.New(), 1)
+	require.NoError(t, repo.Create(stillIn))
+
+	signedOutEarlier := newTestParticipant(uuid.New(), 1)
+	require.NoError(t, repo.Create(signedOutEarlier))
+	earlier := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, repo.Update(signedOutEarlier, map[string]any{"signed_out_at": &earlier}))
+
+	signedOutLater := newTestParticipant(uuid.New(), 1)
+	require.NoError(t, repo.Create(signedOutLater))
+	later := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, repo.Update(signedOutLater, map[string]any{"signed_out_at": &later}))
+
+	// Different event -- must be excluded.
+	require.NoError(t, repo.Create(newTestParticipant(uuid.New(), 2)))
+
+	participants, total, err := repo.List(&models.ListParticipantsFilter{EventID: 1})
+	require.NoError(t, err)
+	require.EqualValues(t, 3, total)
+	require.Len(t, participants, 3)
+
+	require.Equal(t, stillIn.ID, participants[0].ID)
+	require.Equal(t, signedOutLater.ID, participants[1].ID)
+	require.Equal(t, signedOutEarlier.ID, participants[2].ID)
+}
+
+func TestEntryRepository_Update_SignOutThenSignIn(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+
+	participant := newTestParticipant(uuid.New(), 1)
+	require.NoError(t, repo.Create(participant))
+	require.Nil(t, participant.SignedOutAt)
+
+	now := time.Now().UTC()
+	require.NoError(t, repo.Update(participant, map[string]any{"signed_out_at": &now}))
+	require.NotNil(t, participant.SignedOutAt)
+	require.Equal(t, now, *participant.SignedOutAt)
+
+	found, err := repo.FindByID(participant.ID)
+	require.NoError(t, err)
+	require.NotNil(t, found.SignedOutAt)
+
+	require.NoError(t, repo.Update(participant, map[string]any{"signed_out_at": nil}))
+	require.Nil(t, participant.SignedOutAt)
+
+	found, err = repo.FindByID(participant.ID)
+	require.NoError(t, err)
+	require.Nil(t, found.SignedOutAt)
+}
+
+func TestEntryRepository_Update_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+
+	err := repo.Update(&models.Participant{ID: 99999}, map[string]any{"signed_out_at": nil})
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEntryRepository_Delete(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+	membershipID := uuid.New()
+
+	require.NoError(t, repo.Create(newTestParticipant(membershipID, 1)))
+	require.NoError(t, repo.Delete(membershipID, 1))
+
+	_, err := repo.FindByMembershipAndEventID(membershipID, 1)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEntryRepository_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+
+	err := repo.Delete(uuid.New(), 1)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEntryRepository_Clone_Isolation(t *testing.T) {
+	t.Parallel()
+
+	repo := newEntryRepository()
+	membershipID := uuid.New()
+
+	participant := newTestParticipant(membershipID, 1)
+	require.NoError(t, repo.Create(participant))
+
+	clone := repo.clone()
+
+	// Mutating the clone must not affect the original.
+	now := time.Now().UTC()
+	require.NoError(t, clone.Update(&models.Participant{ID: participant.ID}, map[string]any{"signed_out_at": &now}))
+
+	original, err := repo.FindByID(participant.ID)
+	require.NoError(t, err)
+	require.Nil(t, original.SignedOutAt)
+
+	cloned, err := clone.FindByID(participant.ID)
+	require.NoError(t, err)
+	require.NotNil(t, cloned.SignedOutAt)
+
+	// Creating a new entry on the original must not appear in the clone.
+	require.NoError(t, repo.Create(newTestParticipant(uuid.New(), 1)))
+
+	_, cloneTotal, err := clone.List(&models.ListParticipantsFilter{EventID: 1})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, cloneTotal)
+
+	_, originalTotal, err := repo.List(&models.ListParticipantsFilter{EventID: 1})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, originalTotal)
+}

--- a/server/internal/store/inmemory/store.go
+++ b/server/internal/store/inmemory/store.go
@@ -12,6 +12,7 @@ type InMemoryStore struct {
 	memberships *inMemoryMembershipRepository
 	structures  *inMemoryStructureRepository
 	events      *inMemoryEventRepository
+	entries     *inMemoryEntryRepository
 	parent      *InMemoryStore
 }
 
@@ -24,6 +25,7 @@ func NewStore() store.Store {
 		memberships: newMembershipRepository(),
 		structures:  newStructureRepository(),
 		events:      newEventRepository(),
+		entries:     newEntryRepository(),
 	}
 }
 
@@ -57,7 +59,12 @@ func (s *InMemoryStore) Events() store.EventRepository {
 	return s.events
 }
 
-func (s *InMemoryStore) Entries() store.EntryRepository    { return nil }
+func (s *InMemoryStore) Entries() store.EntryRepository {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.entries
+}
+
 func (s *InMemoryStore) Rankings() store.RankingRepository { return nil }
 func (s *InMemoryStore) Logins() store.LoginRepository     { return nil }
 func (s *InMemoryStore) Sessions() store.SessionRepository { return nil }
@@ -85,6 +92,9 @@ func (s *InMemoryStore) BeginTx() (store.Store, error) {
 	if s.events != nil {
 		tx.events = s.events.clone()
 	}
+	if s.entries != nil {
+		tx.entries = s.entries.clone()
+	}
 	return tx, nil
 }
 
@@ -109,6 +119,9 @@ func (s *InMemoryStore) Commit() error {
 	}
 	if s.events != nil {
 		s.parent.events = s.events
+	}
+	if s.entries != nil {
+		s.parent.entries = s.entries
 	}
 	return nil
 }

--- a/server/internal/store/postgres/entry.go
+++ b/server/internal/store/postgres/entry.go
@@ -1,0 +1,94 @@
+package postgres
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"errors"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type postgresEntryRepository struct {
+	db *gorm.DB
+}
+
+var _ store.EntryRepository = (*postgresEntryRepository)(nil)
+
+func NewEntryRepository(db *gorm.DB) store.EntryRepository {
+	return &postgresEntryRepository{db: db}
+}
+
+func (r *postgresEntryRepository) Create(participant *models.Participant) error {
+	return r.db.Create(participant).Error
+}
+
+func (r *postgresEntryRepository) FindByID(id int32) (models.Participant, error) {
+	var participant models.Participant
+
+	if err := r.db.First(&participant, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Participant{}, store.ErrNotFound
+		}
+		return models.Participant{}, err
+	}
+
+	return participant, nil
+}
+
+func (r *postgresEntryRepository) FindByMembershipAndEventID(membershipID uuid.UUID, eventID int32) (models.Participant, error) {
+	var participant models.Participant
+
+	err := r.db.
+		Where("membership_id = ? AND event_id = ?", membershipID, eventID).
+		First(&participant).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Participant{}, store.ErrNotFound
+		}
+		return models.Participant{}, err
+	}
+
+	return participant, nil
+}
+
+func (r *postgresEntryRepository) List(filter *models.ListParticipantsFilter) ([]models.Participant, int64, error) {
+	var total int64
+	if err := r.db.Model(&models.Participant{}).
+		Where("participants.event_id = ?", filter.EventID).
+		Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	query := models.Participant{}.Preload(r.db).
+		Where("participants.event_id = ?", filter.EventID).
+		Order("participants.signed_out_at DESC")
+	query = filter.Pagination.Apply(query)
+
+	var participants []models.Participant
+	if err := query.Find(&participants).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return participants, total, nil
+}
+
+func (r *postgresEntryRepository) Update(participant *models.Participant, values map[string]any) error {
+	return r.db.Omit(clause.Associations).Model(participant).Updates(values).Error
+}
+
+func (r *postgresEntryRepository) Delete(membershipID uuid.UUID, eventID int32) error {
+	result := r.db.
+		Where("event_id = ?", eventID).
+		Delete(&models.Participant{}, "membership_id = ?", membershipID)
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	if result.RowsAffected == 0 {
+		return store.ErrNotFound
+	}
+
+	return nil
+}

--- a/server/internal/store/postgres/entry_store_test.go
+++ b/server/internal/store/postgres/entry_store_test.go
@@ -1,0 +1,78 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Entries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	event, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Store Wiring Event")
+	require.NoError(t, err)
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	s := postgres.NewStore(db)
+
+	participant := &models.Participant{
+		MembershipID: &membership.ID,
+		EventID:      event.ID,
+	}
+	require.NoError(t, s.Entries().Create(participant))
+
+	found, err := s.Entries().FindByID(participant.ID)
+	require.NoError(t, err)
+	require.Equal(t, participant.ID, found.ID)
+}
+
+func TestStore_BeginTx_Entries_Rollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	event, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Rollback Event")
+	require.NoError(t, err)
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	s := postgres.NewStore(db)
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	participant := &models.Participant{
+		MembershipID: &membership.ID,
+		EventID:      event.ID,
+	}
+	require.NoError(t, tx.Entries().Create(participant))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Entries().FindByID(participant.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/postgres/entry_test.go
+++ b/server/internal/store/postgres/entry_test.go
@@ -1,0 +1,328 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntryRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	event, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Test Event")
+	require.NoError(t, err)
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewEntryRepository(db)
+
+	participant := &models.Participant{
+		MembershipID: &membership.ID,
+		EventID:      event.ID,
+	}
+
+	require.NoError(t, repo.Create(participant))
+	require.NotZero(t, participant.ID)
+}
+
+func TestEntryRepository_Create_DuplicateMembershipEvent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	event, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Test Event")
+	require.NoError(t, err)
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewEntryRepository(db)
+
+	_, err = testutils.CreateTestParticipant(db, membership.ID, event.ID)
+	require.NoError(t, err)
+
+	dup := &models.Participant{
+		MembershipID: &membership.ID,
+		EventID:      event.ID,
+	}
+	require.Error(t, repo.Create(dup))
+}
+
+func TestEntryRepository_FindByID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	event, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Test Event")
+	require.NoError(t, err)
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewEntryRepository(db)
+
+	created, err := testutils.CreateTestParticipant(db, membership.ID, event.ID)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, found.ID)
+	require.Equal(t, event.ID, found.EventID)
+	require.Nil(t, found.Membership)
+}
+
+func TestEntryRepository_FindByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewEntryRepository(container.GetDB())
+
+	_, err = repo.FindByID(99999)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEntryRepository_FindByMembershipAndEventID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	eventA, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Event A")
+	require.NoError(t, err)
+	eventB, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Event B")
+	require.NoError(t, err)
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewEntryRepository(db)
+
+	created, err := testutils.CreateTestParticipant(db, membership.ID, eventA.ID)
+	require.NoError(t, err)
+
+	found, err := repo.FindByMembershipAndEventID(membership.ID, eventA.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, found.ID)
+
+	_, err = repo.FindByMembershipAndEventID(membership.ID, eventB.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	_, err = repo.FindByMembershipAndEventID(uuid.New(), eventA.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEntryRepository_List(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	event, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Test Event")
+	require.NoError(t, err)
+	otherEvent, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Other Event")
+	require.NoError(t, err)
+
+	membershipA, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+	membershipB, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[1].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+	membershipC, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[2].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	// Not yet signed out -- must sort first.
+	stillIn, err := testutils.CreateTestParticipant(db, membershipA.ID, event.ID)
+	require.NoError(t, err)
+
+	// Signed out earlier.
+	signedOutEarlier, err := testutils.CreateTestParticipant(db, membershipB.ID, event.ID)
+	require.NoError(t, err)
+	earlier := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Model(signedOutEarlier).Update("signed_out_at", earlier).Error)
+
+	// Signed out later -- must sort between "still in" and "signed out earlier".
+	signedOutLater, err := testutils.CreateTestParticipant(db, membershipC.ID, event.ID)
+	require.NoError(t, err)
+	later := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Model(signedOutLater).Update("signed_out_at", later).Error)
+
+	// Belongs to a different event -- must be excluded.
+	_, err = testutils.CreateTestParticipant(db, membershipA.ID, otherEvent.ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewEntryRepository(db)
+
+	participants, total, err := repo.List(&models.ListParticipantsFilter{EventID: event.ID})
+	require.NoError(t, err)
+	require.EqualValues(t, 3, total)
+	require.Len(t, participants, 3)
+
+	require.Equal(t, stillIn.ID, participants[0].ID)
+	require.Equal(t, signedOutLater.ID, participants[1].ID)
+	require.Equal(t, signedOutEarlier.ID, participants[2].ID)
+
+	require.NotNil(t, participants[0].Membership)
+	require.NotNil(t, participants[0].Membership.User)
+}
+
+func TestEntryRepository_Update_SignOut(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	event, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Test Event")
+	require.NoError(t, err)
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewEntryRepository(db)
+
+	created, err := testutils.CreateTestParticipant(db, membership.ID, event.ID)
+	require.NoError(t, err)
+	require.Nil(t, created.SignedOutAt)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	require.NoError(t, repo.Update(created, map[string]any{"signed_out_at": &now}))
+	require.NotNil(t, created.SignedOutAt)
+	require.WithinDuration(t, now, *created.SignedOutAt, time.Second)
+
+	found, err := repo.FindByID(created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, found.SignedOutAt)
+}
+
+func TestEntryRepository_Update_SignIn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	event, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Test Event")
+	require.NoError(t, err)
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewEntryRepository(db)
+
+	created, err := testutils.CreateTestParticipant(db, membership.ID, event.ID)
+	require.NoError(t, err)
+	now := time.Now().UTC()
+	require.NoError(t, db.Model(created).Update("signed_out_at", now).Error)
+
+	require.NoError(t, repo.Update(created, map[string]any{"signed_out_at": nil}))
+	require.Nil(t, created.SignedOutAt)
+
+	found, err := repo.FindByID(created.ID)
+	require.NoError(t, err)
+	require.Nil(t, found.SignedOutAt)
+}
+
+func TestEntryRepository_Delete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedStructures(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	event, err := testutils.CreateTestEvent(db, testutils.TEST_SEMESTERS[0].ID, testutils.TEST_STRUCTURES[0].ID, "Test Event")
+	require.NoError(t, err)
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewEntryRepository(db)
+
+	_, err = testutils.CreateTestParticipant(db, membership.ID, event.ID)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Delete(membership.ID, event.ID))
+
+	_, err = repo.FindByMembershipAndEventID(membership.ID, event.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestEntryRepository_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewEntryRepository(container.GetDB())
+
+	err = repo.Delete(uuid.New(), 99999)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/postgres/store.go
+++ b/server/internal/store/postgres/store.go
@@ -49,6 +49,7 @@ func NewStore(db *gorm.DB) store.Store {
 		members:     NewMemberRepository(db),
 		structures:  NewStructureRepository(db),
 		events:      NewEventRepository(db),
+		entries:     NewEntryRepository(db),
 	}
 }
 
@@ -101,6 +102,7 @@ func (s *PostgresStore) BeginTx() (store.Store, error) {
 		members:     NewMemberRepository(tx),
 		structures:  NewStructureRepository(tx),
 		events:      NewEventRepository(tx),
+		entries:     NewEntryRepository(tx),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Adds `store.EntryRepository` interface with `Create`, `FindByID`, `FindByMembershipAndEventID`, `List`, `Update`, and `Delete`, following the pattern established by `StructureRepository`, `MembershipRepository`, and `EventRepository`
- Adds `ListParticipantsFilter` model for filtering entries by event with pagination
- Implements `postgresEntryRepository` (GORM-backed) and `inMemoryEntryRepository` (map-backed, with `clone()` for transaction isolation)
- Wires the repository into both `PostgresStore` and `InMemoryStore` constructors, `BeginTx`, and `Commit`
- Query behavior is modeled strictly on the v2 controller path (`entries.go` / `participantsService`); the v1 raw-join `ListParticipants` search behavior is intentionally not covered at this layer (same precedent as `MembershipRepository.List`)
- Does not touch `participants_service.go`, `entries.go`, or `participants_handler.go` — those migrations are tracked separately

## Test plan

- [x] `go build -C server ./...`
- [x] `go test -C server ./internal/store/postgres/... -p=1 --run TestEntryRepository -v` — all pass
- [x] `go test -C server ./internal/store/inmemory/... -p=1 --run TestEntryRepository -v` — all pass, including `clone()` isolation test
- [x] `go test -C server ./internal/store/postgres/... -p=1 --run "TestNewStore_Entries|TestStore_BeginTx_Entries_Rollback" -v` — all pass
- [x] `go test -C server ./internal/store/inmemory/... -p=1 --run "TestNewStore_Entries|TestStore_BeginTx_Entries" -v` — all pass
- [x] `go test -C server ./internal/store/... -p=1` — full store suite passes, no regressions
- [x] `go test -C server ./internal/controller/... ./internal/models/... ./internal/authorization/... -p=1` — no regressions

Closes #352