### PR TITLE
feat(store): implement RankingRepository

### DIFF
--- a/server/internal/store/inmemory/ranking.go
+++ b/server/internal/store/inmemory/ranking.go
@@ -1,0 +1,121 @@
+package inmemory
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type inMemoryRankingRepository struct {
+	mu       sync.RWMutex
+	rankings map[int64]*models.Ranking
+	nextID   int64
+}
+
+var _ store.RankingRepository = (*inMemoryRankingRepository)(nil)
+
+func newRankingRepository() *inMemoryRankingRepository {
+	return &inMemoryRankingRepository{
+		rankings: make(map[int64]*models.Ranking),
+	}
+}
+
+func NewRankingRepository() store.RankingRepository {
+	return newRankingRepository()
+}
+
+func (r *inMemoryRankingRepository) clone() *inMemoryRankingRepository {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	c := &inMemoryRankingRepository{
+		rankings: make(map[int64]*models.Ranking, len(r.rankings)),
+		nextID:   r.nextID,
+	}
+	for id, rk := range r.rankings {
+		rc := *rk
+		c.rankings[id] = &rc
+	}
+	return c
+}
+
+// findByMembershipIDLocked must be called with r.mu already held.
+func (r *inMemoryRankingRepository) findByMembershipIDLocked(membershipID uuid.UUID) *models.Ranking {
+	for _, rk := range r.rankings {
+		if rk.MembershipID == membershipID {
+			return rk
+		}
+	}
+	return nil
+}
+
+func (r *inMemoryRankingRepository) Create(ranking *models.Ranking) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing := r.findByMembershipIDLocked(ranking.MembershipID); existing != nil {
+		return fmt.Errorf("ranking for membership %s already exists", ranking.MembershipID)
+	}
+
+	if ranking.ID == 0 {
+		r.nextID++
+		ranking.ID = r.nextID
+	} else if _, exists := r.rankings[ranking.ID]; exists {
+		return fmt.Errorf("ranking with ID %d already exists", ranking.ID)
+	}
+
+	copy := *ranking
+	r.rankings[ranking.ID] = &copy
+
+	return nil
+}
+
+func (r *inMemoryRankingRepository) FindByMembershipID(membershipID uuid.UUID) (models.Ranking, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	ranking := r.findByMembershipIDLocked(membershipID)
+	if ranking == nil {
+		return models.Ranking{}, store.ErrNotFound
+	}
+
+	return *ranking, nil
+}
+
+func (r *inMemoryRankingRepository) Update(ranking *models.Ranking) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	existing, exists := r.rankings[ranking.ID]
+	if !exists {
+		return store.ErrNotFound
+	}
+
+	existing.Points = ranking.Points
+
+	return nil
+}
+
+func (r *inMemoryRankingRepository) BatchIncrementPoints(updates map[uuid.UUID]int32) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for membershipID, points := range updates {
+		if existing := r.findByMembershipIDLocked(membershipID); existing != nil {
+			existing.Points += points
+			continue
+		}
+
+		r.nextID++
+		r.rankings[r.nextID] = &models.Ranking{
+			ID:           r.nextID,
+			MembershipID: membershipID,
+			Points:       points,
+		}
+	}
+
+	return nil
+}

--- a/server/internal/store/inmemory/ranking_store_test.go
+++ b/server/internal/store/inmemory/ranking_store_test.go
@@ -1,0 +1,62 @@
+package inmemory
+
+import (
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Rankings(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	ranking := &models.Ranking{MembershipID: uuid.New(), Points: 10}
+	require.NoError(t, s.Rankings().Create(ranking))
+
+	found, err := s.Rankings().FindByMembershipID(ranking.MembershipID)
+	require.NoError(t, err)
+	require.Equal(t, ranking.ID, found.ID)
+}
+
+func TestStore_BeginTx_Rankings_Commit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	ranking := &models.Ranking{MembershipID: uuid.New(), Points: 10}
+	require.NoError(t, tx.Rankings().Create(ranking))
+
+	// The parent store must not see the ranking until Commit is called.
+	_, err = s.Rankings().FindByMembershipID(ranking.MembershipID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.NoError(t, tx.Commit())
+
+	found, err := s.Rankings().FindByMembershipID(ranking.MembershipID)
+	require.NoError(t, err)
+	require.Equal(t, ranking.ID, found.ID)
+}
+
+func TestStore_BeginTx_Rankings_DiscardedWithoutCommit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	ranking := &models.Ranking{MembershipID: uuid.New(), Points: 10}
+	require.NoError(t, tx.Rankings().Create(ranking))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Rankings().FindByMembershipID(ranking.MembershipID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/inmemory/ranking_test.go
+++ b/server/internal/store/inmemory/ranking_test.go
@@ -1,0 +1,165 @@
+package inmemory
+
+import (
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRankingRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+
+	ranking := &models.Ranking{MembershipID: uuid.New(), Points: 10}
+	require.NoError(t, repo.Create(ranking))
+	require.NotZero(t, ranking.ID)
+}
+
+func TestRankingRepository_Create_DuplicateMembership(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+	membershipID := uuid.New()
+
+	require.NoError(t, repo.Create(&models.Ranking{MembershipID: membershipID, Points: 5}))
+
+	err := repo.Create(&models.Ranking{MembershipID: membershipID, Points: 1})
+	require.Error(t, err)
+}
+
+func TestRankingRepository_FindByMembershipID(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+	membershipID := uuid.New()
+
+	created := &models.Ranking{MembershipID: membershipID, Points: 15}
+	require.NoError(t, repo.Create(created))
+
+	found, err := repo.FindByMembershipID(membershipID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, found.ID)
+	require.EqualValues(t, 15, found.Points)
+
+	_, err = repo.FindByMembershipID(uuid.New())
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestRankingRepository_Update(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+	membershipID := uuid.New()
+
+	created := &models.Ranking{MembershipID: membershipID, Points: 5}
+	require.NoError(t, repo.Create(created))
+
+	created.Points = 20
+	require.NoError(t, repo.Update(created))
+
+	found, err := repo.FindByMembershipID(membershipID)
+	require.NoError(t, err)
+	require.EqualValues(t, 20, found.Points)
+}
+
+func TestRankingRepository_Update_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+
+	err := repo.Update(&models.Ranking{ID: 99999, Points: 1})
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestRankingRepository_BatchIncrementPoints_CreatesForNewMembership(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+	membershipID := uuid.New()
+
+	require.NoError(t, repo.BatchIncrementPoints(map[uuid.UUID]int32{membershipID: 12}))
+
+	found, err := repo.FindByMembershipID(membershipID)
+	require.NoError(t, err)
+	require.EqualValues(t, 12, found.Points)
+}
+
+func TestRankingRepository_BatchIncrementPoints_IncrementsExisting(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+	membershipID := uuid.New()
+	require.NoError(t, repo.Create(&models.Ranking{MembershipID: membershipID, Points: 8}))
+
+	require.NoError(t, repo.BatchIncrementPoints(map[uuid.UUID]int32{membershipID: 5}))
+
+	found, err := repo.FindByMembershipID(membershipID)
+	require.NoError(t, err)
+	require.EqualValues(t, 13, found.Points)
+}
+
+func TestRankingRepository_BatchIncrementPoints_Mixed(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+	existingID := uuid.New()
+	newID := uuid.New()
+	require.NoError(t, repo.Create(&models.Ranking{MembershipID: existingID, Points: 3}))
+
+	require.NoError(t, repo.BatchIncrementPoints(map[uuid.UUID]int32{
+		existingID: 7,
+		newID:      4,
+	}))
+
+	foundExisting, err := repo.FindByMembershipID(existingID)
+	require.NoError(t, err)
+	require.EqualValues(t, 10, foundExisting.Points)
+
+	foundNew, err := repo.FindByMembershipID(newID)
+	require.NoError(t, err)
+	require.EqualValues(t, 4, foundNew.Points)
+}
+
+func TestRankingRepository_BatchIncrementPoints_Empty(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+
+	require.NoError(t, repo.BatchIncrementPoints(map[uuid.UUID]int32{}))
+}
+
+func TestRankingRepository_Clone_Isolation(t *testing.T) {
+	t.Parallel()
+
+	repo := newRankingRepository()
+	membershipID := uuid.New()
+
+	ranking := &models.Ranking{MembershipID: membershipID, Points: 5}
+	require.NoError(t, repo.Create(ranking))
+
+	clone := repo.clone()
+
+	// Mutating the clone must not affect the original.
+	require.NoError(t, clone.Update(&models.Ranking{ID: ranking.ID, MembershipID: membershipID, Points: 99}))
+
+	original, err := repo.FindByMembershipID(membershipID)
+	require.NoError(t, err)
+	require.EqualValues(t, 5, original.Points)
+
+	cloned, err := clone.FindByMembershipID(membershipID)
+	require.NoError(t, err)
+	require.EqualValues(t, 99, cloned.Points)
+
+	// Creating a new ranking on the original must not appear in the clone.
+	require.NoError(t, repo.Create(&models.Ranking{MembershipID: uuid.New(), Points: 1}))
+
+	_, err = clone.FindByMembershipID(membershipID)
+	require.NoError(t, err)
+	require.Len(t, clone.rankings, 1)
+	require.Len(t, repo.rankings, 2)
+}

--- a/server/internal/store/inmemory/store.go
+++ b/server/internal/store/inmemory/store.go
@@ -13,6 +13,7 @@ type InMemoryStore struct {
 	structures  *inMemoryStructureRepository
 	events      *inMemoryEventRepository
 	entries     *inMemoryEntryRepository
+	rankings    *inMemoryRankingRepository
 	parent      *InMemoryStore
 }
 
@@ -26,6 +27,7 @@ func NewStore() store.Store {
 		structures:  newStructureRepository(),
 		events:      newEventRepository(),
 		entries:     newEntryRepository(),
+		rankings:    newRankingRepository(),
 	}
 }
 
@@ -65,7 +67,12 @@ func (s *InMemoryStore) Entries() store.EntryRepository {
 	return s.entries
 }
 
-func (s *InMemoryStore) Rankings() store.RankingRepository { return nil }
+func (s *InMemoryStore) Rankings() store.RankingRepository {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.rankings
+}
+
 func (s *InMemoryStore) Logins() store.LoginRepository     { return nil }
 func (s *InMemoryStore) Sessions() store.SessionRepository { return nil }
 
@@ -95,6 +102,9 @@ func (s *InMemoryStore) BeginTx() (store.Store, error) {
 	if s.entries != nil {
 		tx.entries = s.entries.clone()
 	}
+	if s.rankings != nil {
+		tx.rankings = s.rankings.clone()
+	}
 	return tx, nil
 }
 
@@ -122,6 +132,9 @@ func (s *InMemoryStore) Commit() error {
 	}
 	if s.entries != nil {
 		s.parent.entries = s.entries
+	}
+	if s.rankings != nil {
+		s.parent.rankings = s.rankings
 	}
 	return nil
 }

--- a/server/internal/store/postgres/ranking.go
+++ b/server/internal/store/postgres/ranking.go
@@ -1,0 +1,66 @@
+package postgres
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type postgresRankingRepository struct {
+	db *gorm.DB
+}
+
+var _ store.RankingRepository = (*postgresRankingRepository)(nil)
+
+func NewRankingRepository(db *gorm.DB) store.RankingRepository {
+	return &postgresRankingRepository{db: db}
+}
+
+func (r *postgresRankingRepository) Create(ranking *models.Ranking) error {
+	return r.db.Create(ranking).Error
+}
+
+func (r *postgresRankingRepository) FindByMembershipID(membershipID uuid.UUID) (models.Ranking, error) {
+	var ranking models.Ranking
+
+	err := r.db.Where("membership_id = ?", membershipID).First(&ranking).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Ranking{}, store.ErrNotFound
+		}
+		return models.Ranking{}, err
+	}
+
+	return ranking, nil
+}
+
+func (r *postgresRankingRepository) Update(ranking *models.Ranking) error {
+	return r.db.Model(ranking).Select("points").Updates(ranking).Error
+}
+
+func (r *postgresRankingRepository) BatchIncrementPoints(updates map[uuid.UUID]int32) error {
+	if len(updates) == 0 {
+		return nil
+	}
+
+	valueStrings := make([]string, 0, len(updates))
+	args := make([]interface{}, 0, len(updates)*2)
+	i := 1
+	for membershipID, points := range updates {
+		valueStrings = append(valueStrings, fmt.Sprintf("($%d::uuid, $%d, 0)", i, i+1))
+		args = append(args, membershipID, points)
+		i += 2
+	}
+
+	query := fmt.Sprintf(
+		`INSERT INTO rankings (membership_id, points, attendance) VALUES %s ON CONFLICT (membership_id) DO UPDATE SET points = rankings.points + EXCLUDED.points`,
+		strings.Join(valueStrings, ", "),
+	)
+
+	return r.db.Exec(query, args...).Error
+}

--- a/server/internal/store/postgres/ranking_store_test.go
+++ b/server/internal/store/postgres/ranking_store_test.go
@@ -1,0 +1,66 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Rankings(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	s := postgres.NewStore(db)
+
+	ranking := &models.Ranking{MembershipID: membership.ID, Points: 10}
+	require.NoError(t, s.Rankings().Create(ranking))
+
+	found, err := s.Rankings().FindByMembershipID(membership.ID)
+	require.NoError(t, err)
+	require.Equal(t, ranking.ID, found.ID)
+}
+
+func TestStore_BeginTx_Rankings_Rollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	s := postgres.NewStore(db)
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	ranking := &models.Ranking{MembershipID: membership.ID, Points: 10}
+	require.NoError(t, tx.Rankings().Create(ranking))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Rankings().FindByMembershipID(membership.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/postgres/ranking_test.go
+++ b/server/internal/store/postgres/ranking_test.go
@@ -1,0 +1,257 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRankingRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewRankingRepository(db)
+
+	ranking := &models.Ranking{
+		MembershipID: membership.ID,
+		Points:       10,
+	}
+
+	require.NoError(t, repo.Create(ranking))
+	require.NotZero(t, ranking.ID)
+}
+
+func TestRankingRepository_Create_DuplicateMembership(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewRankingRepository(db)
+
+	require.NoError(t, repo.Create(&models.Ranking{MembershipID: membership.ID, Points: 5}))
+
+	dup := &models.Ranking{MembershipID: membership.ID, Points: 1}
+	require.Error(t, repo.Create(dup))
+}
+
+func TestRankingRepository_FindByMembershipID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewRankingRepository(db)
+
+	created := &models.Ranking{MembershipID: membership.ID, Points: 15}
+	require.NoError(t, repo.Create(created))
+
+	found, err := repo.FindByMembershipID(membership.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.ID, found.ID)
+	require.EqualValues(t, 15, found.Points)
+}
+
+func TestRankingRepository_FindByMembershipID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewRankingRepository(container.GetDB())
+
+	_, err = repo.FindByMembershipID(uuid.New())
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestRankingRepository_Update(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewRankingRepository(db)
+
+	created := &models.Ranking{MembershipID: membership.ID, Points: 5}
+	require.NoError(t, repo.Create(created))
+
+	created.Points = 20
+	require.NoError(t, repo.Update(created))
+
+	found, err := repo.FindByMembershipID(membership.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 20, found.Points)
+}
+
+func TestRankingRepository_Update_ToZero(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewRankingRepository(db)
+
+	created := &models.Ranking{MembershipID: membership.ID, Points: 5}
+	require.NoError(t, repo.Create(created))
+
+	// Regression guard: Points=0 is GORM's zero value and must not be silently
+	// dropped by Updates -- Update must use Select("points") to force it through.
+	created.Points = 0
+	require.NoError(t, repo.Update(created))
+
+	found, err := repo.FindByMembershipID(membership.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, found.Points)
+}
+
+func TestRankingRepository_BatchIncrementPoints_CreatesForNewMembership(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewRankingRepository(db)
+
+	require.NoError(t, repo.BatchIncrementPoints(map[uuid.UUID]int32{membership.ID: 12}))
+
+	found, err := repo.FindByMembershipID(membership.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 12, found.Points)
+}
+
+func TestRankingRepository_BatchIncrementPoints_IncrementsExisting(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	membership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewRankingRepository(db)
+	require.NoError(t, repo.Create(&models.Ranking{MembershipID: membership.ID, Points: 8}))
+
+	require.NoError(t, repo.BatchIncrementPoints(map[uuid.UUID]int32{membership.ID: 5}))
+
+	found, err := repo.FindByMembershipID(membership.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 13, found.Points)
+}
+
+func TestRankingRepository_BatchIncrementPoints_Mixed(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, testutils.SeedSemesters(db))
+	require.NoError(t, testutils.SeedUsers(db))
+
+	existingMembership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[0].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+	newMembership, err := testutils.CreateTestMembership(db, testutils.TEST_USERS[1].ID, testutils.TEST_SEMESTERS[0].ID)
+	require.NoError(t, err)
+
+	repo := postgres.NewRankingRepository(db)
+	require.NoError(t, repo.Create(&models.Ranking{MembershipID: existingMembership.ID, Points: 3}))
+
+	require.NoError(t, repo.BatchIncrementPoints(map[uuid.UUID]int32{
+		existingMembership.ID: 7,
+		newMembership.ID:      4,
+	}))
+
+	foundExisting, err := repo.FindByMembershipID(existingMembership.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 10, foundExisting.Points)
+
+	foundNew, err := repo.FindByMembershipID(newMembership.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, 4, foundNew.Points)
+}
+
+func TestRankingRepository_BatchIncrementPoints_Empty(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewRankingRepository(container.GetDB())
+
+	require.NoError(t, repo.BatchIncrementPoints(map[uuid.UUID]int32{}))
+}

--- a/server/internal/store/postgres/store.go
+++ b/server/internal/store/postgres/store.go
@@ -50,6 +50,7 @@ func NewStore(db *gorm.DB) store.Store {
 		structures:  NewStructureRepository(db),
 		events:      NewEventRepository(db),
 		entries:     NewEntryRepository(db),
+		rankings:    NewRankingRepository(db),
 	}
 }
 
@@ -103,6 +104,7 @@ func (s *PostgresStore) BeginTx() (store.Store, error) {
 		structures:  NewStructureRepository(tx),
 		events:      NewEventRepository(tx),
 		entries:     NewEntryRepository(tx),
+		rankings:    NewRankingRepository(tx),
 	}, nil
 }
 

--- a/server/internal/store/ranking.go
+++ b/server/internal/store/ranking.go
@@ -1,4 +1,26 @@
 package store
 
-// RankingRepository is the interface for accessing the rankings in the data store. It provides methods for creating, reading, updating, and deleting rankings.
-type RankingRepository interface {}
+import (
+	"api/internal/models"
+
+	"github.com/google/uuid"
+)
+
+// RankingRepository is the interface for accessing the rankings in the data store. It provides
+// methods for creating, reading, updating, and batch-upserting rankings.
+type RankingRepository interface {
+	// Create creates a new ranking in the data store.
+	Create(ranking *models.Ranking) error
+
+	// FindByMembershipID retrieves a ranking from the data store by its membership ID.
+	// Returns store.ErrNotFound if no ranking exists for the given membership.
+	FindByMembershipID(membershipID uuid.UUID) (models.Ranking, error)
+
+	// Update updates the points on an existing ranking, identified by ranking.ID.
+	Update(ranking *models.Ranking) error
+
+	// BatchIncrementPoints creates or increments rankings for the given memberships in a single
+	// operation: memberships with no existing ranking get one created with the given points;
+	// memberships with an existing ranking have their points incremented by the given amount.
+	BatchIncrementPoints(updates map[uuid.UUID]int32) error
+}


### PR DESCRIPTION
## Summary

- Adds `store.RankingRepository` interface with `Create`, `FindByMembershipID`, `Update`, and `BatchIncrementPoints`, following the pattern established by `StructureRepository` and `EntryRepository`
- Implements `postgresRankingRepository` (GORM-backed) and `inMemoryRankingRepository` (map-backed, with `clone()` for transaction isolation)
- Wires the repository into both `PostgresStore` and `InMemoryStore` constructors, `BeginTx`, and `Commit`
- Interface covers only the base `rankings` table queries `ranking_service.go` actually runs (`UpdateRanking`'s find-then-create-or-increment, `BatchUpdateRankings`'s bulk upsert). `GetRanking` (which queries `semester_rankings_view`, a cross-table join) is intentionally excluded, matching the precedent set by `EntryRepository.List` and `MembershipRepository.List` declining multi-table queries
- Does not touch `ranking_service.go`, `points_service.go`, `semester_service.go`, or any controller — those migrations are tracked separately

## Test plan

- [x] `go build -C server ./...`
- [x] `go test -C server ./internal/store/postgres/... -p=1 --run TestRankingRepository -v` — all pass
- [x] `go test -C server ./internal/store/inmemory/... -p=1 --run TestRankingRepository -v` — all pass, including `clone()` isolation test
- [x] `go test -C server ./internal/store/postgres/... -p=1 --run "TestNewStore_Rankings|TestStore_BeginTx_Rankings_Rollback" -v` — all pass
- [x] `go test -C server ./internal/store/inmemory/... -p=1 --run "TestNewStore_Rankings|TestStore_BeginTx_Rankings" -v` — all pass
- [x] `go test -C server ./internal/store/... -p=1` — full store suite passes, no regressions
- [x] `go test -C server ./internal/controller/... ./internal/models/... ./internal/authorization/... -p=1` — no regressions

Closes #353