### PR TITLE
Implement LoginRepository for the store layer

### DIFF
--- a/server/internal/store/inmemory/login.go
+++ b/server/internal/store/inmemory/login.go
@@ -1,0 +1,97 @@
+package inmemory
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"fmt"
+	"sync"
+)
+
+type inMemoryLoginRepository struct {
+	mu     sync.RWMutex
+	logins map[string]*models.Login
+}
+
+var _ store.LoginRepository = (*inMemoryLoginRepository)(nil)
+
+func newLoginRepository() *inMemoryLoginRepository {
+	return &inMemoryLoginRepository{
+		logins: make(map[string]*models.Login),
+	}
+}
+
+func NewLoginRepository() store.LoginRepository {
+	return newLoginRepository()
+}
+
+func (r *inMemoryLoginRepository) clone() *inMemoryLoginRepository {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	c := &inMemoryLoginRepository{
+		logins: make(map[string]*models.Login, len(r.logins)),
+	}
+	for username, l := range r.logins {
+		lc := *l
+		c.logins[username] = &lc
+	}
+	return c
+}
+
+func (r *inMemoryLoginRepository) Create(login *models.Login) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.logins[login.Username]; exists {
+		return fmt.Errorf("login with username %q already exists", login.Username)
+	}
+
+	copy := *login
+	r.logins[login.Username] = &copy
+
+	return nil
+}
+
+func (r *inMemoryLoginRepository) FindByUsername(username string) (models.Login, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	login, exists := r.logins[username]
+	if !exists {
+		return models.Login{}, store.ErrNotFound
+	}
+
+	return *login, nil
+}
+
+func (r *inMemoryLoginRepository) Update(username string, values map[string]any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	login, exists := r.logins[username]
+	if !exists {
+		return store.ErrNotFound
+	}
+
+	if password, ok := values["password"]; ok {
+		login.Password = password.(string)
+	}
+	if role, ok := values["role"]; ok {
+		login.Role = role.(string)
+	}
+
+	return nil
+}
+
+func (r *inMemoryLoginRepository) Delete(username string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.logins[username]; !exists {
+		return store.ErrNotFound
+	}
+
+	delete(r.logins, username)
+
+	return nil
+}

--- a/server/internal/store/inmemory/login_store_test.go
+++ b/server/internal/store/inmemory/login_store_test.go
@@ -1,0 +1,61 @@
+package inmemory
+
+import (
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Logins(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	login := &models.Login{Username: "alice", Password: "hash1", Role: "executive"}
+	require.NoError(t, s.Logins().Create(login))
+
+	found, err := s.Logins().FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "hash1", found.Password)
+}
+
+func TestStore_BeginTx_Logins_Commit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	login := &models.Login{Username: "alice", Password: "hash1", Role: "executive"}
+	require.NoError(t, tx.Logins().Create(login))
+
+	// The parent store must not see the login until Commit is called.
+	_, err = s.Logins().FindByUsername("alice")
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.NoError(t, tx.Commit())
+
+	found, err := s.Logins().FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "hash1", found.Password)
+}
+
+func TestStore_BeginTx_Logins_DiscardedWithoutCommit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	login := &models.Login{Username: "alice", Password: "hash1", Role: "executive"}
+	require.NoError(t, tx.Logins().Create(login))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Logins().FindByUsername("alice")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/inmemory/login_test.go
+++ b/server/internal/store/inmemory/login_test.go
@@ -1,0 +1,135 @@
+package inmemory
+
+import (
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoginRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	repo := newLoginRepository()
+
+	login := &models.Login{Username: "alice", Password: "hash1", Role: "executive"}
+	require.NoError(t, repo.Create(login))
+}
+
+func TestLoginRepository_Create_DuplicateUsername(t *testing.T) {
+	t.Parallel()
+
+	repo := newLoginRepository()
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	err := repo.Create(&models.Login{Username: "alice", Password: "hash2", Role: "president"})
+	require.Error(t, err)
+}
+
+func TestLoginRepository_FindByUsername(t *testing.T) {
+	t.Parallel()
+
+	repo := newLoginRepository()
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	found, err := repo.FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "hash1", found.Password)
+	require.Equal(t, "executive", found.Role)
+
+	_, err = repo.FindByUsername("nobody")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestLoginRepository_Update(t *testing.T) {
+	t.Parallel()
+
+	repo := newLoginRepository()
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	require.NoError(t, repo.Update("alice", map[string]any{"role": "president"}))
+
+	found, err := repo.FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "president", found.Role)
+	require.Equal(t, "hash1", found.Password)
+}
+
+func TestLoginRepository_Update_PartialFields(t *testing.T) {
+	t.Parallel()
+
+	repo := newLoginRepository()
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	require.NoError(t, repo.Update("alice", map[string]any{"password": "hash2"}))
+
+	found, err := repo.FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "hash2", found.Password)
+	require.Equal(t, "executive", found.Role)
+}
+
+func TestLoginRepository_Update_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := newLoginRepository()
+
+	err := repo.Update("nobody", map[string]any{"role": "president"})
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestLoginRepository_Delete(t *testing.T) {
+	t.Parallel()
+
+	repo := newLoginRepository()
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+	require.NoError(t, repo.Delete("alice"))
+
+	_, err := repo.FindByUsername("alice")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestLoginRepository_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := newLoginRepository()
+
+	err := repo.Delete("nobody")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestLoginRepository_Clone_Isolation(t *testing.T) {
+	t.Parallel()
+
+	repo := newLoginRepository()
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	clone := repo.clone()
+
+	// Mutating the clone must not affect the original.
+	require.NoError(t, clone.Update("alice", map[string]any{"role": "president"}))
+
+	original, err := repo.FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "executive", original.Role)
+
+	cloned, err := clone.FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "president", cloned.Role)
+
+	// Creating a new login on the original must not appear in the clone.
+	require.NoError(t, repo.Create(&models.Login{Username: "bob", Password: "hash2", Role: "secretary"}))
+
+	_, err = clone.FindByUsername("bob")
+	require.ErrorIs(t, err, store.ErrNotFound)
+	require.Len(t, clone.logins, 1)
+	require.Len(t, repo.logins, 2)
+}

--- a/server/internal/store/inmemory/store.go
+++ b/server/internal/store/inmemory/store.go
@@ -14,6 +14,7 @@ type InMemoryStore struct {
 	events      *inMemoryEventRepository
 	entries     *inMemoryEntryRepository
 	rankings    *inMemoryRankingRepository
+	logins      *inMemoryLoginRepository
 	parent      *InMemoryStore
 }
 
@@ -28,6 +29,7 @@ func NewStore() store.Store {
 		events:      newEventRepository(),
 		entries:     newEntryRepository(),
 		rankings:    newRankingRepository(),
+		logins:      newLoginRepository(),
 	}
 }
 
@@ -73,7 +75,12 @@ func (s *InMemoryStore) Rankings() store.RankingRepository {
 	return s.rankings
 }
 
-func (s *InMemoryStore) Logins() store.LoginRepository     { return nil }
+func (s *InMemoryStore) Logins() store.LoginRepository {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.logins
+}
+
 func (s *InMemoryStore) Sessions() store.SessionRepository { return nil }
 
 // BeginTx snapshots all active repos into a new InMemoryStore. The returned
@@ -105,6 +112,9 @@ func (s *InMemoryStore) BeginTx() (store.Store, error) {
 	if s.rankings != nil {
 		tx.rankings = s.rankings.clone()
 	}
+	if s.logins != nil {
+		tx.logins = s.logins.clone()
+	}
 	return tx, nil
 }
 
@@ -135,6 +145,9 @@ func (s *InMemoryStore) Commit() error {
 	}
 	if s.rankings != nil {
 		s.parent.rankings = s.rankings
+	}
+	if s.logins != nil {
+		s.parent.logins = s.logins
 	}
 	return nil
 }

--- a/server/internal/store/login.go
+++ b/server/internal/store/login.go
@@ -1,4 +1,22 @@
 package store
 
-// LoginRepository is the interface for accessing the logins in the data store. It provides methods for creating, reading, updating, and deleting logins.
-type LoginRepository interface {}
+import "api/internal/models"
+
+// LoginRepository is the interface for accessing the logins in the data store. It provides
+// methods for creating, reading, updating, and deleting logins.
+type LoginRepository interface {
+	// Create creates a new login in the data store.
+	Create(login *models.Login) error
+
+	// FindByUsername retrieves a login from the data store by its username.
+	// Returns store.ErrNotFound if no login exists for the given username.
+	FindByUsername(username string) (models.Login, error)
+
+	// Update applies a partial update to a login using the given column/value map.
+	// Returns store.ErrNotFound if no login exists for the given username.
+	Update(username string, values map[string]any) error
+
+	// Delete deletes a login from the data store by its username.
+	// Returns store.ErrNotFound if no login exists for the given username.
+	Delete(username string) error
+}

--- a/server/internal/store/postgres/login.go
+++ b/server/internal/store/postgres/login.go
@@ -1,0 +1,63 @@
+package postgres
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"errors"
+
+	"gorm.io/gorm"
+)
+
+type postgresLoginRepository struct {
+	db *gorm.DB
+}
+
+var _ store.LoginRepository = (*postgresLoginRepository)(nil)
+
+func NewLoginRepository(db *gorm.DB) store.LoginRepository {
+	return &postgresLoginRepository{db: db}
+}
+
+func (r *postgresLoginRepository) Create(login *models.Login) error {
+	return r.db.Create(login).Error
+}
+
+func (r *postgresLoginRepository) FindByUsername(username string) (models.Login, error) {
+	var login models.Login
+
+	err := r.db.Where("username = ?", username).First(&login).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Login{}, store.ErrNotFound
+		}
+		return models.Login{}, err
+	}
+
+	return login, nil
+}
+
+func (r *postgresLoginRepository) Update(username string, values map[string]any) error {
+	result := r.db.Model(&models.Login{}).Where("username = ?", username).Updates(values)
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	if result.RowsAffected == 0 {
+		return store.ErrNotFound
+	}
+
+	return nil
+}
+
+func (r *postgresLoginRepository) Delete(username string) error {
+	result := r.db.Where("username = ?", username).Delete(&models.Login{})
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	if result.RowsAffected == 0 {
+		return store.ErrNotFound
+	}
+
+	return nil
+}

--- a/server/internal/store/postgres/login_store_test.go
+++ b/server/internal/store/postgres/login_store_test.go
@@ -1,0 +1,52 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Logins(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	s := postgres.NewStore(container.GetDB())
+
+	login := &models.Login{Username: "alice", Password: "hash1", Role: "executive"}
+	require.NoError(t, s.Logins().Create(login))
+
+	found, err := s.Logins().FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "hash1", found.Password)
+}
+
+func TestStore_BeginTx_Logins_Rollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	s := postgres.NewStore(container.GetDB())
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	login := &models.Login{Username: "alice", Password: "hash1", Role: "executive"}
+	require.NoError(t, tx.Logins().Create(login))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Logins().FindByUsername("alice")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/postgres/login_test.go
+++ b/server/internal/store/postgres/login_test.go
@@ -1,0 +1,161 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoginRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewLoginRepository(container.GetDB())
+
+	login := &models.Login{Username: "alice", Password: "hash1", Role: "executive"}
+	require.NoError(t, repo.Create(login))
+}
+
+func TestLoginRepository_Create_DuplicateUsername(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewLoginRepository(container.GetDB())
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	dup := &models.Login{Username: "alice", Password: "hash2", Role: "president"}
+	require.Error(t, repo.Create(dup))
+}
+
+func TestLoginRepository_FindByUsername(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewLoginRepository(container.GetDB())
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	found, err := repo.FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "hash1", found.Password)
+	require.Equal(t, "executive", found.Role)
+}
+
+func TestLoginRepository_FindByUsername_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewLoginRepository(container.GetDB())
+
+	_, err = repo.FindByUsername("nobody")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestLoginRepository_Update(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewLoginRepository(container.GetDB())
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	require.NoError(t, repo.Update("alice", map[string]any{"role": "president"}))
+
+	found, err := repo.FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "president", found.Role)
+	require.Equal(t, "hash1", found.Password)
+}
+
+func TestLoginRepository_Update_PartialFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewLoginRepository(container.GetDB())
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	// Updating only password must leave role untouched.
+	require.NoError(t, repo.Update("alice", map[string]any{"password": "hash2"}))
+
+	found, err := repo.FindByUsername("alice")
+	require.NoError(t, err)
+	require.Equal(t, "hash2", found.Password)
+	require.Equal(t, "executive", found.Role)
+}
+
+func TestLoginRepository_Update_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewLoginRepository(container.GetDB())
+
+	err = repo.Update("nobody", map[string]any{"role": "president"})
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestLoginRepository_Delete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewLoginRepository(container.GetDB())
+
+	require.NoError(t, repo.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+	require.NoError(t, repo.Delete("alice"))
+
+	_, err = repo.FindByUsername("alice")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestLoginRepository_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewLoginRepository(container.GetDB())
+
+	err = repo.Delete("nobody")
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/postgres/store.go
+++ b/server/internal/store/postgres/store.go
@@ -51,6 +51,7 @@ func NewStore(db *gorm.DB) store.Store {
 		events:      NewEventRepository(db),
 		entries:     NewEntryRepository(db),
 		rankings:    NewRankingRepository(db),
+		logins:      NewLoginRepository(db),
 	}
 }
 
@@ -105,6 +106,7 @@ func (s *PostgresStore) BeginTx() (store.Store, error) {
 		events:      NewEventRepository(tx),
 		entries:     NewEntryRepository(tx),
 		rankings:    NewRankingRepository(tx),
+		logins:      NewLoginRepository(tx),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Adds `store.LoginRepository` interface with `Create`, `FindByUsername`, `Update`, and `Delete`, following the pattern established by `StructureRepository` and refined by `RankingRepository`
- Implements `postgresLoginRepository` (GORM-backed) and `inMemoryLoginRepository` (map-backed, with `clone()` for transaction isolation), keyed by `Username` (the model's GORM primary key)
- Wires the repository into both `PostgresStore` and `InMemoryStore` constructors, `BeginTx`, and `Commit`
- Interface covers only the base `logins` table queries `login_service.go` actually runs (`CreateLogin`'s insert, `DeleteLogin`/`UpdateLogin`'s update-and-check-`RowsAffected`), plus `FindByUsername` as the read path every other single-table repository exposes. `ListLogins`/`GetLogin` (which query `logins LEFT JOIN users`, a cross-table join) are intentionally excluded, matching the precedent set by `EntryRepository.List` and `RankingRepository` declining multi-table queries
- Does not touch `login_service.go`, `credentials_service.go`, or `controller/logins.go` — those migrations are tracked separately

## Test plan

- [x] `go build -C server ./...`
- [x] `go test -C server ./internal/store/postgres/... -p=1 --run TestLoginRepository -v` — 9/9 pass
- [x] `go test -C server ./internal/store/inmemory/... -p=1 --run TestLoginRepository -v` — 9/9 pass, including `clone()` isolation test
- [x] `go test -C server ./internal/store/postgres/... -p=1 --run "TestNewStore_Logins|TestStore_BeginTx_Logins_Rollback" -v` — all pass
- [x] `go test -C server ./internal/store/inmemory/... -p=1 --run "TestNewStore_Logins|TestStore_BeginTx_Logins" -v` — all pass
- [x] `go test -C server ./internal/store/... -p=1` — full store suite passes, no regressions

Closes #354
