### PR TITLE
Implement session repository

### DIFF
--- a/server/internal/store/inmemory/session.go
+++ b/server/internal/store/inmemory/session.go
@@ -1,0 +1,82 @@
+package inmemory
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+type inMemorySessionRepository struct {
+	mu       sync.RWMutex
+	sessions map[uuid.UUID]*models.Session
+}
+
+var _ store.SessionRepository = (*inMemorySessionRepository)(nil)
+
+func newSessionRepository() *inMemorySessionRepository {
+	return &inMemorySessionRepository{
+		sessions: make(map[uuid.UUID]*models.Session),
+	}
+}
+
+func NewSessionRepository() store.SessionRepository {
+	return newSessionRepository()
+}
+
+func (r *inMemorySessionRepository) clone() *inMemorySessionRepository {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	c := &inMemorySessionRepository{
+		sessions: make(map[uuid.UUID]*models.Session, len(r.sessions)),
+	}
+	for id, s := range r.sessions {
+		sc := *s
+		c.sessions[id] = &sc
+	}
+	return c
+}
+
+func (r *inMemorySessionRepository) Create(session *models.Session) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if session.ID == uuid.Nil {
+		session.ID = uuid.New()
+	} else if _, exists := r.sessions[session.ID]; exists {
+		return fmt.Errorf("session with ID %s already exists", session.ID)
+	}
+
+	copy := *session
+	r.sessions[session.ID] = &copy
+
+	return nil
+}
+
+func (r *inMemorySessionRepository) FindByID(id uuid.UUID) (models.Session, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	session, exists := r.sessions[id]
+	if !exists {
+		return models.Session{}, store.ErrNotFound
+	}
+
+	return *session, nil
+}
+
+func (r *inMemorySessionRepository) Delete(id uuid.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.sessions[id]; !exists {
+		return store.ErrNotFound
+	}
+
+	delete(r.sessions, id)
+
+	return nil
+}

--- a/server/internal/store/inmemory/session_store_test.go
+++ b/server/internal/store/inmemory/session_store_test.go
@@ -1,0 +1,65 @@
+package inmemory
+
+import (
+	"testing"
+	"time"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Sessions(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, s.Sessions().Create(session))
+
+	found, err := s.Sessions().FindByID(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, "alice", found.Username)
+}
+
+func TestStore_BeginTx_Sessions_Commit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, tx.Sessions().Create(session))
+
+	// The parent store must not see the session until Commit is called.
+	_, err = s.Sessions().FindByID(session.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	require.NoError(t, tx.Commit())
+
+	found, err := s.Sessions().FindByID(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, "alice", found.Username)
+}
+
+func TestStore_BeginTx_Sessions_DiscardedWithoutCommit(t *testing.T) {
+	t.Parallel()
+
+	s := NewStore()
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, tx.Sessions().Create(session))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Sessions().FindByID(session.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/inmemory/session_test.go
+++ b/server/internal/store/inmemory/session_test.go
@@ -1,0 +1,109 @@
+package inmemory
+
+import (
+	"testing"
+	"time"
+
+	"api/internal/models"
+	"api/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	repo := newSessionRepository()
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, repo.Create(session))
+	require.NotEqual(t, uuid.Nil, session.ID)
+}
+
+func TestSessionRepository_Create_DuplicateID(t *testing.T) {
+	t.Parallel()
+
+	repo := newSessionRepository()
+
+	id := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, repo.Create(&models.Session{ID: id, StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}))
+
+	dup := &models.Session{ID: id, StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "bob", Role: "executive"}
+	require.Error(t, repo.Create(dup))
+}
+
+func TestSessionRepository_FindByID(t *testing.T) {
+	t.Parallel()
+
+	repo := newSessionRepository()
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(time.Hour)
+	session := &models.Session{StartedAt: now, ExpiresAt: expiresAt, Username: "alice", Role: "executive"}
+	require.NoError(t, repo.Create(session))
+
+	found, err := repo.FindByID(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, "alice", found.Username)
+	require.Equal(t, "executive", found.Role)
+	require.Equal(t, expiresAt, found.ExpiresAt)
+
+	_, err = repo.FindByID(uuid.New())
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestSessionRepository_Delete(t *testing.T) {
+	t.Parallel()
+
+	repo := newSessionRepository()
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, repo.Create(session))
+	require.NoError(t, repo.Delete(session.ID))
+
+	_, err := repo.FindByID(session.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestSessionRepository_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := newSessionRepository()
+
+	err := repo.Delete(uuid.New())
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestSessionRepository_Clone_Isolation(t *testing.T) {
+	t.Parallel()
+
+	repo := newSessionRepository()
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, repo.Create(session))
+
+	clone := repo.clone()
+
+	// Deleting from the clone must not affect the original.
+	require.NoError(t, clone.Delete(session.ID))
+
+	_, err := repo.FindByID(session.ID)
+	require.NoError(t, err)
+
+	_, err = clone.FindByID(session.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+
+	// Creating a new session on the original must not appear in the clone.
+	other := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "bob", Role: "executive"}
+	require.NoError(t, repo.Create(other))
+
+	_, err = clone.FindByID(other.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+	require.Len(t, clone.sessions, 0)
+	require.Len(t, repo.sessions, 2)
+}

--- a/server/internal/store/inmemory/store.go
+++ b/server/internal/store/inmemory/store.go
@@ -15,6 +15,7 @@ type InMemoryStore struct {
 	entries     *inMemoryEntryRepository
 	rankings    *inMemoryRankingRepository
 	logins      *inMemoryLoginRepository
+	sessions    *inMemorySessionRepository
 	parent      *InMemoryStore
 }
 
@@ -30,6 +31,7 @@ func NewStore() store.Store {
 		entries:     newEntryRepository(),
 		rankings:    newRankingRepository(),
 		logins:      newLoginRepository(),
+		sessions:    newSessionRepository(),
 	}
 }
 
@@ -81,7 +83,11 @@ func (s *InMemoryStore) Logins() store.LoginRepository {
 	return s.logins
 }
 
-func (s *InMemoryStore) Sessions() store.SessionRepository { return nil }
+func (s *InMemoryStore) Sessions() store.SessionRepository {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.sessions
+}
 
 // BeginTx snapshots all active repos into a new InMemoryStore. The returned
 // store operates on its own copy of the data, leaving the parent untouched
@@ -114,6 +120,9 @@ func (s *InMemoryStore) BeginTx() (store.Store, error) {
 	}
 	if s.logins != nil {
 		tx.logins = s.logins.clone()
+	}
+	if s.sessions != nil {
+		tx.sessions = s.sessions.clone()
 	}
 	return tx, nil
 }
@@ -148,6 +157,9 @@ func (s *InMemoryStore) Commit() error {
 	}
 	if s.logins != nil {
 		s.parent.logins = s.logins
+	}
+	if s.sessions != nil {
+		s.parent.sessions = s.sessions
 	}
 	return nil
 }

--- a/server/internal/store/postgres/session.go
+++ b/server/internal/store/postgres/session.go
@@ -1,0 +1,51 @@
+package postgres
+
+import (
+	"api/internal/models"
+	"api/internal/store"
+	"errors"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type postgresSessionRepository struct {
+	db *gorm.DB
+}
+
+var _ store.SessionRepository = (*postgresSessionRepository)(nil)
+
+func NewSessionRepository(db *gorm.DB) store.SessionRepository {
+	return &postgresSessionRepository{db: db}
+}
+
+func (r *postgresSessionRepository) Create(session *models.Session) error {
+	return r.db.Create(session).Error
+}
+
+func (r *postgresSessionRepository) FindByID(id uuid.UUID) (models.Session, error) {
+	var session models.Session
+
+	err := r.db.Where("id = ?", id).First(&session).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.Session{}, store.ErrNotFound
+		}
+		return models.Session{}, err
+	}
+
+	return session, nil
+}
+
+func (r *postgresSessionRepository) Delete(id uuid.UUID) error {
+	result := r.db.Where("id = ?", id).Delete(&models.Session{})
+	if err := result.Error; err != nil {
+		return err
+	}
+
+	if result.RowsAffected == 0 {
+		return store.ErrNotFound
+	}
+
+	return nil
+}

--- a/server/internal/store/postgres/session_store_test.go
+++ b/server/internal/store/postgres/session_store_test.go
@@ -1,0 +1,59 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStore_Sessions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	s := postgres.NewStore(container.GetDB())
+
+	require.NoError(t, s.Logins().Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, s.Sessions().Create(session))
+
+	found, err := s.Sessions().FindByID(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, "alice", found.Username)
+}
+
+func TestStore_BeginTx_Sessions_Rollback(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	s := postgres.NewStore(container.GetDB())
+
+	require.NoError(t, s.Logins().Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}))
+
+	tx, err := s.BeginTx()
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, tx.Sessions().Create(session))
+	require.NoError(t, tx.Rollback())
+
+	_, err = s.Sessions().FindByID(session.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/postgres/session_test.go
+++ b/server/internal/store/postgres/session_test.go
@@ -1,0 +1,125 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"api/internal/models"
+	"api/internal/store"
+	"api/internal/store/postgres"
+	"api/internal/testutils"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionRepository_Create(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, db.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}).Error)
+
+	repo := postgres.NewSessionRepository(db)
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, repo.Create(session))
+	require.NotEqual(t, uuid.Nil, session.ID)
+}
+
+func TestSessionRepository_Create_UnknownUsername(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewSessionRepository(container.GetDB())
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "nobody", Role: "executive"}
+	require.Error(t, repo.Create(session))
+}
+
+func TestSessionRepository_FindByID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, db.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}).Error)
+
+	repo := postgres.NewSessionRepository(db)
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(time.Hour)
+	session := &models.Session{StartedAt: now, ExpiresAt: expiresAt, Username: "alice", Role: "executive"}
+	require.NoError(t, repo.Create(session))
+
+	found, err := repo.FindByID(session.ID)
+	require.NoError(t, err)
+	require.Equal(t, "alice", found.Username)
+	require.Equal(t, "executive", found.Role)
+	require.WithinDuration(t, expiresAt, found.ExpiresAt, time.Second)
+}
+
+func TestSessionRepository_FindByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewSessionRepository(container.GetDB())
+
+	_, err = repo.FindByID(uuid.New())
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestSessionRepository_Delete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	db := container.GetDB()
+	require.NoError(t, db.Create(&models.Login{Username: "alice", Password: "hash1", Role: "executive"}).Error)
+
+	repo := postgres.NewSessionRepository(db)
+
+	now := time.Now().UTC()
+	session := &models.Session{StartedAt: now, ExpiresAt: now.Add(time.Hour), Username: "alice", Role: "executive"}
+	require.NoError(t, repo.Create(session))
+
+	require.NoError(t, repo.Delete(session.ID))
+
+	_, err = repo.FindByID(session.ID)
+	require.ErrorIs(t, err, store.ErrNotFound)
+}
+
+func TestSessionRepository_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	container, err := testutils.NewPostgresContainer(ctx, testutils.PostgresConfig{})
+	require.NoError(t, err)
+	defer container.Close(ctx)
+
+	repo := postgres.NewSessionRepository(container.GetDB())
+
+	err = repo.Delete(uuid.New())
+	require.ErrorIs(t, err, store.ErrNotFound)
+}

--- a/server/internal/store/postgres/store.go
+++ b/server/internal/store/postgres/store.go
@@ -52,6 +52,7 @@ func NewStore(db *gorm.DB) store.Store {
 		entries:     NewEntryRepository(db),
 		rankings:    NewRankingRepository(db),
 		logins:      NewLoginRepository(db),
+		sessions:    NewSessionRepository(db),
 	}
 }
 
@@ -107,6 +108,7 @@ func (s *PostgresStore) BeginTx() (store.Store, error) {
 		entries:     NewEntryRepository(tx),
 		rankings:    NewRankingRepository(tx),
 		logins:      NewLoginRepository(tx),
+		sessions:    NewSessionRepository(tx),
 	}, nil
 }
 

--- a/server/internal/store/session.go
+++ b/server/internal/store/session.go
@@ -1,4 +1,22 @@
 package store
 
-// SessionRepository is the interface for accessing the sessions in the data store. It provides methods for creating, reading, updating, and deleting sessions.
-type SessionRepository interface {}
+import (
+	"api/internal/models"
+
+	"github.com/google/uuid"
+)
+
+// SessionRepository is the interface for accessing the sessions in the data store. It provides
+// methods for creating, reading, and deleting sessions.
+type SessionRepository interface {
+	// Create creates a new session in the data store.
+	Create(session *models.Session) error
+
+	// FindByID retrieves a session from the data store by its ID.
+	// Returns store.ErrNotFound if no session exists for the given ID.
+	FindByID(id uuid.UUID) (models.Session, error)
+
+	// Delete deletes a session from the data store by its ID.
+	// Returns store.ErrNotFound if no session exists for the given ID.
+	Delete(id uuid.UUID) error
+}


### PR DESCRIPTION
## Summary

Implements `store.SessionRepository` (Postgres and in-memory), following the pattern established by `LoginRepository` (PR #364). Closes #355.

- `store.SessionRepository` interface: `Create`, `FindByID`, `Delete`, mirroring the base-table queries `session_manager.go` runs directly (`Create`'s insert, `Invalidate`'s delete-by-ID, and the lookup half of `Authenticate`'s find-by-ID)
- `postgresSessionRepository`: GORM-backed implementation
- `inMemorySessionRepository`: map-backed implementation with `clone()` for transaction isolation
- Wired into both `PostgresStore` and `InMemoryStore` (`NewStore`, `BeginTx`, `Commit`)

Out of scope (per issue #355 and tracked separately in #356): migrating `session_manager.go`, `credentials_service.go`, or `authentication.go` (v2 controller) to use the new repository. `Authenticate`'s expiry check and conditional delete remain business logic in the service layer, not part of this repository.

## Test plan

- [x] `go test -C server ./internal/store/postgres/... -p=1` — all passing, including new session repository and store-wiring tests
- [x] `go test -C server ./internal/store/inmemory/... -p=1` — all passing, including new session repository, `clone()` isolation, and store-wiring tests
- [x] `go test -C server ./internal/controller/... -p=1` — no regressions
- [x] `go build -C server ./...` — clean